### PR TITLE
Add report service skeleton and API docs

### DIFF
--- a/MICROSERVICE_API.md
+++ b/MICROSERVICE_API.md
@@ -1,0 +1,31 @@
+# Microservice API Definitions
+
+This document outlines the gRPC interfaces for core microservices in the EvolutionAI interview platform.
+
+## Auth Service
+- `rpc RegisterUser(RegisterUserRequest) returns (UserResponse)`
+- `rpc LoginUser(LoginRequest) returns (LoginResponse)`
+
+## Job Service
+- `rpc CreateJob(CreateJobRequest) returns (JobResponse)`
+- `rpc GetJob(JobRequest) returns (JobResponse)`
+- `rpc ListJobs(ListJobsRequest) returns (ListJobsResponse)`
+
+## Candidate Service
+- `rpc CreateCandidate(CreateCandidateRequest) returns (CandidateResponse)`
+- `rpc GetCandidate(CandidateRequest) returns (CandidateResponse)`
+- `rpc ListCandidates(ListCandidatesRequest) returns (ListCandidatesResponse)`
+
+## Interview Service
+- `rpc StartInterview(StartInterviewRequest) returns (InterviewResponse)`
+- `rpc SubmitAnswer(SubmitAnswerRequest) returns (InterviewResponse)`
+- `rpc GetInterview(InterviewRequest) returns (InterviewResponse)`
+
+## Report Service
+- `rpc GenerateReport(GenerateReportRequest) returns (ReportResponse)`
+- `rpc GetReport(GetReportRequest) returns (ReportResponse)`
+
+## Notification Service
+- `rpc SendInvitation(SendInvitationRequest) returns (SendInvitationResponse)`
+
+Each service maintains its own data store and communicates over gRPC to ensure loose coupling and scalability.

--- a/src/main/java/com/example/grpcdemo/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/ReportServiceImpl.java
@@ -1,0 +1,47 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.proto.GenerateReportRequest;
+import com.example.grpcdemo.proto.GetReportRequest;
+import com.example.grpcdemo.proto.ReportResponse;
+import com.example.grpcdemo.proto.ReportServiceGrpc;
+
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@GrpcService
+public class ReportServiceImpl extends ReportServiceGrpc.ReportServiceImplBase {
+
+    private final Map<String, ReportResponse> reportStore = new ConcurrentHashMap<>();
+
+    @Override
+    public void generateReport(GenerateReportRequest request,
+                               StreamObserver<ReportResponse> responseObserver) {
+        String reportId = UUID.randomUUID().toString();
+        ReportResponse response = ReportResponse.newBuilder()
+                .setReportId(reportId)
+                .setInterviewId(request.getInterviewId())
+                .setContent("Report placeholder")
+                .build();
+        reportStore.put(reportId, response);
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getReport(GetReportRequest request,
+                          StreamObserver<ReportResponse> responseObserver) {
+        ReportResponse response = reportStore.getOrDefault(
+                request.getReportId(),
+                ReportResponse.newBuilder()
+                        .setReportId(request.getReportId())
+                        .setInterviewId("")
+                        .setContent("Not Found")
+                        .build());
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+}

--- a/src/main/proto/report.proto
+++ b/src/main/proto/report.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.example.grpcdemo.proto";
+option java_outer_classname = "ReportProto";
+
+package report;
+
+service ReportService {
+  rpc GenerateReport(GenerateReportRequest) returns (ReportResponse);
+  rpc GetReport(GetReportRequest) returns (ReportResponse);
+}
+
+message GenerateReportRequest {
+  string interviewId = 1;
+}
+
+message GetReportRequest {
+  string reportId = 1;
+}
+
+message ReportResponse {
+  string reportId = 1;
+  string interviewId = 2;
+  string content = 3;
+}


### PR DESCRIPTION
## Summary
- document gRPC interfaces for core microservices
- add placeholder Report service proto and implementation

## Testing
- `mvn -q test` (fails: Non-resolvable parent POM; network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68c129af800c83319d29eca1d13d52d9