### PR TITLE
Add ReportService with NOT_FOUND error handling

### DIFF
--- a/src/main/java/com/example/grpcdemo/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/ReportServiceImpl.java
@@ -1,0 +1,42 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.proto.CreateReportRequest;
+import com.example.grpcdemo.proto.ReportRequest;
+import com.example.grpcdemo.proto.ReportResponse;
+import com.example.grpcdemo.proto.ReportServiceGrpc;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@GrpcService
+public class ReportServiceImpl extends ReportServiceGrpc.ReportServiceImplBase {
+
+    private final Map<String, ReportResponse> reportStore = new ConcurrentHashMap<>();
+
+    @Override
+    public void createReport(CreateReportRequest request, StreamObserver<ReportResponse> responseObserver) {
+        String id = UUID.randomUUID().toString();
+        ReportResponse report = ReportResponse.newBuilder()
+                .setReportId(id)
+                .setContent(request.getContent())
+                .build();
+        reportStore.put(id, report);
+        responseObserver.onNext(report);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getReport(ReportRequest request, StreamObserver<ReportResponse> responseObserver) {
+        ReportResponse report = reportStore.get(request.getReportId());
+        if (report == null) {
+            responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
+            return;
+        }
+        responseObserver.onNext(report);
+        responseObserver.onCompleted();
+    }
+}

--- a/src/main/proto/report.proto
+++ b/src/main/proto/report.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.example.grpcdemo.proto";
+option java_outer_classname = "ReportProto";
+
+package report;
+
+service ReportService {
+  rpc CreateReport (CreateReportRequest) returns (ReportResponse);
+  rpc GetReport (ReportRequest) returns (ReportResponse);
+}
+
+message CreateReportRequest {
+  string content = 1;
+}
+
+message ReportRequest {
+  string reportId = 1;
+}
+
+message ReportResponse {
+  string reportId = 1;
+  string content = 2;
+}

--- a/src/test/java/com/example/grpcdemo/service/ReportServiceImplTest.java
+++ b/src/test/java/com/example/grpcdemo/service/ReportServiceImplTest.java
@@ -1,0 +1,63 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.proto.CreateReportRequest;
+import com.example.grpcdemo.proto.ReportRequest;
+import com.example.grpcdemo.proto.ReportResponse;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReportServiceImplTest {
+
+    private static class TestObserver<T> implements StreamObserver<T> {
+        T value;
+        Throwable error;
+        boolean completed;
+
+        @Override
+        public void onNext(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            this.error = t;
+        }
+
+        @Override
+        public void onCompleted() {
+            this.completed = true;
+        }
+    }
+
+    @Test
+    void getReport_missingId_returnsNotFound() {
+        ReportServiceImpl service = new ReportServiceImpl();
+        TestObserver<ReportResponse> observer = new TestObserver<>();
+
+        service.getReport(ReportRequest.newBuilder().setReportId("missing").build(), observer);
+
+        assertNotNull(observer.error);
+        assertTrue(observer.error instanceof StatusRuntimeException);
+        assertEquals(Status.NOT_FOUND.getCode(), ((StatusRuntimeException) observer.error).getStatus().getCode());
+    }
+
+    @Test
+    void getReport_existingId_returnsReport() {
+        ReportServiceImpl service = new ReportServiceImpl();
+        TestObserver<ReportResponse> createObserver = new TestObserver<>();
+        service.createReport(CreateReportRequest.newBuilder().setContent("hello").build(), createObserver);
+        String id = createObserver.value.getReportId();
+
+        TestObserver<ReportResponse> observer = new TestObserver<>();
+        service.getReport(ReportRequest.newBuilder().setReportId(id).build(), observer);
+
+        assertNull(observer.error);
+        assertTrue(observer.completed);
+        assertEquals(id, observer.value.getReportId());
+        assertEquals("hello", observer.value.getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce ReportService proto and implementation
- Return NOT_FOUND via onError when a report ID is absent
- Cover error propagation with unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c13fd8ce0c8331a73cd1674c36d63c