### PR TITLE
Implement JPA-backed gRPC services for hiring workflow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,17 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
+        <!-- Data JPA and H2 for persistence -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- gRPC Server -->
         <dependency>
             <groupId>net.devh</groupId>

--- a/src/main/java/com/example/grpcdemo/model/Candidate.java
+++ b/src/main/java/com/example/grpcdemo/model/Candidate.java
@@ -1,0 +1,59 @@
+package com.example.grpcdemo.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * JPA entity representing a candidate.
+ */
+@Entity
+public class Candidate {
+
+    @Id
+    private String id;
+    private String name;
+    private String email;
+    private String phone;
+    private String status;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}
+

--- a/src/main/java/com/example/grpcdemo/model/Interview.java
+++ b/src/main/java/com/example/grpcdemo/model/Interview.java
@@ -1,0 +1,59 @@
+package com.example.grpcdemo.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * JPA entity representing an interview.
+ */
+@Entity
+public class Interview {
+
+    @Id
+    private String id;
+    private String candidateId;
+    private String jobId;
+    private String scheduledTime;
+    private String status;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getCandidateId() {
+        return candidateId;
+    }
+
+    public void setCandidateId(String candidateId) {
+        this.candidateId = candidateId;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    public String getScheduledTime() {
+        return scheduledTime;
+    }
+
+    public void setScheduledTime(String scheduledTime) {
+        this.scheduledTime = scheduledTime;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}
+

--- a/src/main/java/com/example/grpcdemo/model/Job.java
+++ b/src/main/java/com/example/grpcdemo/model/Job.java
@@ -1,0 +1,50 @@
+package com.example.grpcdemo.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * JPA entity representing a job posting.
+ */
+@Entity
+public class Job {
+
+    @Id
+    private String id;
+    private String jobTitle;
+    private String description;
+    private String status;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getJobTitle() {
+        return jobTitle;
+    }
+
+    public void setJobTitle(String jobTitle) {
+        this.jobTitle = jobTitle;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}
+

--- a/src/main/java/com/example/grpcdemo/repository/CandidateRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/CandidateRepository.java
@@ -1,0 +1,11 @@
+package com.example.grpcdemo.repository;
+
+import com.example.grpcdemo.model.Candidate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for {@link Candidate} entities.
+ */
+public interface CandidateRepository extends JpaRepository<Candidate, String> {
+}
+

--- a/src/main/java/com/example/grpcdemo/repository/InterviewRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/InterviewRepository.java
@@ -1,0 +1,17 @@
+package com.example.grpcdemo.repository;
+
+import com.example.grpcdemo.model.Interview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Repository for {@link Interview} entities.
+ */
+public interface InterviewRepository extends JpaRepository<Interview, String> {
+
+    List<Interview> findByCandidateId(String candidateId);
+
+    List<Interview> findByJobId(String jobId);
+}
+

--- a/src/main/java/com/example/grpcdemo/repository/JobRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/JobRepository.java
@@ -1,0 +1,11 @@
+package com.example.grpcdemo.repository;
+
+import com.example.grpcdemo.model.Job;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for {@link Job} entities.
+ */
+public interface JobRepository extends JpaRepository<Job, String> {
+}
+

--- a/src/main/java/com/example/grpcdemo/service/CandidateServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/CandidateServiceImpl.java
@@ -1,58 +1,76 @@
 package com.example.grpcdemo.service;
 
+import com.example.grpcdemo.model.Candidate;
 import com.example.grpcdemo.proto.CandidateRequest;
 import com.example.grpcdemo.proto.CandidateResponse;
 import com.example.grpcdemo.proto.CandidateServiceGrpc;
 import com.example.grpcdemo.proto.CreateCandidateRequest;
 import com.example.grpcdemo.proto.ListCandidatesRequest;
 import com.example.grpcdemo.proto.ListCandidatesResponse;
+import com.example.grpcdemo.repository.CandidateRepository;
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
 
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
+/**
+ * gRPC service implementation for candidates backed by JPA.
+ */
 @GrpcService
 public class CandidateServiceImpl extends CandidateServiceGrpc.CandidateServiceImplBase {
 
-    private final Map<String, CandidateResponse> candidates = new ConcurrentHashMap<>();
+    private final CandidateRepository repository;
+
+    public CandidateServiceImpl(CandidateRepository repository) {
+        this.repository = repository;
+    }
 
     @Override
     public void createCandidate(CreateCandidateRequest request, StreamObserver<CandidateResponse> responseObserver) {
-        String id = UUID.randomUUID().toString();
-        CandidateResponse response = CandidateResponse.newBuilder()
-                .setCandidateId(id)
-                .setName(request.getName())
-                .setEmail(request.getEmail())
-                .setPhone(request.getPhone())
-                .setStatus("CREATED")
-                .build();
-        candidates.put(id, response);
+        Candidate candidate = new Candidate();
+        candidate.setId(UUID.randomUUID().toString());
+        candidate.setName(request.getName());
+        candidate.setEmail(request.getEmail());
+        candidate.setPhone(request.getPhone());
+        candidate.setStatus("CREATED");
+        Candidate saved = repository.save(candidate);
+
+        CandidateResponse response = toResponse(saved);
         responseObserver.onNext(response);
         responseObserver.onCompleted();
     }
 
     @Override
     public void getCandidate(CandidateRequest request, StreamObserver<CandidateResponse> responseObserver) {
-        CandidateResponse found = candidates.getOrDefault(
-                request.getCandidateId(),
-                CandidateResponse.newBuilder()
+        CandidateResponse response = repository.findById(request.getCandidateId())
+                .map(this::toResponse)
+                .orElse(CandidateResponse.newBuilder()
                         .setCandidateId(request.getCandidateId())
                         .setStatus("NOT_FOUND")
-                        .build()
-        );
-        responseObserver.onNext(found);
+                        .build());
+        responseObserver.onNext(response);
         responseObserver.onCompleted();
     }
 
     @Override
     public void listCandidates(ListCandidatesRequest request, StreamObserver<ListCandidatesResponse> responseObserver) {
-        ListCandidatesResponse response = ListCandidatesResponse.newBuilder()
-                .addAllCandidates(new ArrayList<>(candidates.values()))
-                .build();
-        responseObserver.onNext(response);
+        List<CandidateResponse> list = repository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+        responseObserver.onNext(ListCandidatesResponse.newBuilder().addAllCandidates(list).build());
         responseObserver.onCompleted();
     }
+
+    private CandidateResponse toResponse(Candidate candidate) {
+        return CandidateResponse.newBuilder()
+                .setCandidateId(candidate.getId())
+                .setName(candidate.getName())
+                .setEmail(candidate.getEmail())
+                .setPhone(candidate.getPhone())
+                .setStatus(candidate.getStatus())
+                .build();
+    }
 }
+

--- a/src/main/java/com/example/grpcdemo/service/JobServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/JobServiceImpl.java
@@ -1,57 +1,72 @@
 package com.example.grpcdemo.service;
 
+import com.example.grpcdemo.model.Job;
 import com.example.grpcdemo.proto.CreateJobRequest;
 import com.example.grpcdemo.proto.JobRequest;
 import com.example.grpcdemo.proto.JobResponse;
 import com.example.grpcdemo.proto.JobServiceGrpc;
 import com.example.grpcdemo.proto.ListJobsRequest;
 import com.example.grpcdemo.proto.ListJobsResponse;
+import com.example.grpcdemo.repository.JobRepository;
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
 
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
+/**
+ * gRPC service implementation for jobs backed by JPA.
+ */
 @GrpcService
 public class JobServiceImpl extends JobServiceGrpc.JobServiceImplBase {
 
-    private final Map<String, JobResponse> jobs = new ConcurrentHashMap<>();
+    private final JobRepository repository;
+
+    public JobServiceImpl(JobRepository repository) {
+        this.repository = repository;
+    }
 
     @Override
     public void getJob(JobRequest request, StreamObserver<JobResponse> responseObserver) {
-        JobResponse response = jobs.getOrDefault(
-                request.getJobId(),
-                JobResponse.newBuilder()
+        JobResponse response = repository.findById(request.getJobId())
+                .map(this::toResponse)
+                .orElse(JobResponse.newBuilder()
                         .setJobId(request.getJobId())
                         .setStatus("NOT_FOUND")
-                        .build()
-        );
+                        .build());
         responseObserver.onNext(response);
         responseObserver.onCompleted();
     }
 
     @Override
     public void createJob(CreateJobRequest request, StreamObserver<JobResponse> responseObserver) {
-        String id = UUID.randomUUID().toString();
-        JobResponse response = JobResponse.newBuilder()
-                .setJobId(id)
-                .setJobTitle(request.getJobTitle())
-                .setStatus("CREATED")
-                .build();
-        jobs.put(id, response);
-        responseObserver.onNext(response);
+        Job job = new Job();
+        job.setId(UUID.randomUUID().toString());
+        job.setJobTitle(request.getJobTitle());
+        job.setDescription(request.getDescription());
+        job.setStatus("CREATED");
+        Job saved = repository.save(job);
+
+        responseObserver.onNext(toResponse(saved));
         responseObserver.onCompleted();
     }
 
     @Override
     public void listJobs(ListJobsRequest request, StreamObserver<ListJobsResponse> responseObserver) {
-        ListJobsResponse response = ListJobsResponse.newBuilder()
-                .addAllJobs(new ArrayList<>(jobs.values()))
-                .build();
-        responseObserver.onNext(response);
+        List<JobResponse> list = repository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+        responseObserver.onNext(ListJobsResponse.newBuilder().addAllJobs(list).build());
         responseObserver.onCompleted();
+    }
+
+    private JobResponse toResponse(Job job) {
+        return JobResponse.newBuilder()
+                .setJobId(job.getId())
+                .setJobTitle(job.getJobTitle())
+                .setStatus(job.getStatus())
+                .build();
     }
 }
 

--- a/src/test/java/com/example/grpcdemo/GrpcDemoApplicationTests.java
+++ b/src/test/java/com/example/grpcdemo/GrpcDemoApplicationTests.java
@@ -1,4 +1,4 @@
-package com.example.demo;
+package com.example.grpcdemo;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/example/grpcdemo/service/ServiceIntegrationTest.java
+++ b/src/test/java/com/example/grpcdemo/service/ServiceIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.proto.CandidateResponse;
+import com.example.grpcdemo.proto.ConfirmInterviewRequest;
+import com.example.grpcdemo.proto.CreateCandidateRequest;
+import com.example.grpcdemo.proto.CreateJobRequest;
+import com.example.grpcdemo.proto.GetInterviewsByCandidateRequest;
+import com.example.grpcdemo.proto.InterviewResponse;
+import com.example.grpcdemo.proto.InterviewsResponse;
+import com.example.grpcdemo.proto.JobResponse;
+import com.example.grpcdemo.proto.ScheduleInterviewRequest;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Integration tests verifying basic CRUD and state transitions for gRPC services.
+ */
+@SpringBootTest
+class ServiceIntegrationTest {
+
+    @Autowired
+    private CandidateServiceImpl candidateService;
+    @Autowired
+    private JobServiceImpl jobService;
+    @Autowired
+    private InterviewServiceImpl interviewService;
+
+    @Test
+    void fullWorkflow() {
+        // create candidate
+        ResponseObserver<CandidateResponse> candObs = new ResponseObserver<>();
+        candidateService.createCandidate(CreateCandidateRequest.newBuilder()
+                .setName("Alice")
+                .setEmail("alice@example.com")
+                .setPhone("123")
+                .build(), candObs);
+        CandidateResponse candidate = candObs.value;
+        Assertions.assertEquals("CREATED", candidate.getStatus());
+
+        // create job
+        ResponseObserver<JobResponse> jobObs = new ResponseObserver<>();
+        jobService.createJob(CreateJobRequest.newBuilder()
+                .setJobTitle("Dev")
+                .setDescription("Desc")
+                .build(), jobObs);
+        JobResponse job = jobObs.value;
+        Assertions.assertEquals("CREATED", job.getStatus());
+
+        // schedule interview
+        ResponseObserver<InterviewResponse> interviewObs = new ResponseObserver<>();
+        interviewService.scheduleInterview(ScheduleInterviewRequest.newBuilder()
+                .setCandidateId(candidate.getCandidateId())
+                .setJobId(job.getJobId())
+                .setScheduledTime("2025-09-11T10:00:00Z")
+                .build(), interviewObs);
+        InterviewResponse interview = interviewObs.value;
+        Assertions.assertEquals("SCHEDULED", interview.getStatus());
+
+        // confirm interview
+        ResponseObserver<InterviewResponse> confirmObs = new ResponseObserver<>();
+        interviewService.confirmInterview(ConfirmInterviewRequest.newBuilder()
+                .setInterviewId(interview.getInterviewId())
+                .setAccepted(true)
+                .build(), confirmObs);
+        InterviewResponse confirmed = confirmObs.value;
+        Assertions.assertEquals("CONFIRMED", confirmed.getStatus());
+
+        // list interviews by candidate
+        ResponseObserver<InterviewsResponse> listObs = new ResponseObserver<>();
+        interviewService.getInterviewsByCandidate(GetInterviewsByCandidateRequest.newBuilder()
+                .setCandidateId(candidate.getCandidateId())
+                .build(), listObs);
+        InterviewsResponse interviews = listObs.value;
+        Assertions.assertEquals(1, interviews.getInterviewsCount());
+    }
+
+    /** Simple StreamObserver capturing the last value. */
+    private static class ResponseObserver<T> implements StreamObserver<T> {
+        private T value;
+
+        @Override
+        public void onNext(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            throw new RuntimeException(t);
+        }
+
+        @Override
+        public void onCompleted() {
+            // no-op
+        }
+    }
+}
+

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- add Candidate, Job, Interview JPA entities and repositories
- implement gRPC services using persistence and status transitions
- provide integration tests verifying candidate/job/interview flow

## Testing
- `mvn -q protobuf:compile` *(fails: Non-resolvable parent POM; network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c21d90003083319be12f67b29b4d86