### PR TITLE
feat: persist reports and add tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,17 @@
             <version>2.15.0.RELEASE</version>
         </dependency>
 
+        <!-- Persistence -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Protobuf -->
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/src/main/java/com/example/grpcdemo/entity/ReportEntity.java
+++ b/src/main/java/com/example/grpcdemo/entity/ReportEntity.java
@@ -1,0 +1,87 @@
+package com.example.grpcdemo.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+/**
+ * JPA entity representing a stored report.
+ */
+@Entity
+@Table(name = "reports")
+public class ReportEntity {
+
+    @Id
+    private String reportId;
+    private String interviewId;
+
+    @Lob
+    private String content;
+
+    private float score;
+    private String evaluatorComment;
+    private long createdAt;
+
+    public ReportEntity() {
+    }
+
+    public ReportEntity(String reportId, String interviewId, String content,
+                        float score, String evaluatorComment, long createdAt) {
+        this.reportId = reportId;
+        this.interviewId = interviewId;
+        this.content = content;
+        this.score = score;
+        this.evaluatorComment = evaluatorComment;
+        this.createdAt = createdAt;
+    }
+
+    public String getReportId() {
+        return reportId;
+    }
+
+    public void setReportId(String reportId) {
+        this.reportId = reportId;
+    }
+
+    public String getInterviewId() {
+        return interviewId;
+    }
+
+    public void setInterviewId(String interviewId) {
+        this.interviewId = interviewId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public float getScore() {
+        return score;
+    }
+
+    public void setScore(float score) {
+        this.score = score;
+    }
+
+    public String getEvaluatorComment() {
+        return evaluatorComment;
+    }
+
+    public void setEvaluatorComment(String evaluatorComment) {
+        this.evaluatorComment = evaluatorComment;
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(long createdAt) {
+        this.createdAt = createdAt;
+    }
+}
+

--- a/src/main/java/com/example/grpcdemo/repository/ReportRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/ReportRepository.java
@@ -1,0 +1,11 @@
+package com.example.grpcdemo.repository;
+
+import com.example.grpcdemo.entity.ReportEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for {@link ReportEntity}.
+ */
+public interface ReportRepository extends JpaRepository<ReportEntity, String> {
+}
+

--- a/src/main/java/com/example/grpcdemo/service/AiEvaluationClient.java
+++ b/src/main/java/com/example/grpcdemo/service/AiEvaluationClient.java
@@ -1,0 +1,16 @@
+package com.example.grpcdemo.service;
+
+/**
+ * Client used to obtain AI evaluation results for interviews.
+ */
+public interface AiEvaluationClient {
+
+    /**
+     * Evaluate an interview and return analysis results.
+     *
+     * @param interviewId the interview identifier
+     * @return the evaluation result
+     */
+    EvaluationResult evaluate(String interviewId);
+}
+

--- a/src/main/java/com/example/grpcdemo/service/EvaluationResult.java
+++ b/src/main/java/com/example/grpcdemo/service/EvaluationResult.java
@@ -1,0 +1,12 @@
+package com.example.grpcdemo.service;
+
+/**
+ * Simple DTO holding AI evaluation results.
+ *
+ * @param content textual report content
+ * @param score numerical score from 0 to 1
+ * @param comment evaluator comments
+ */
+public record EvaluationResult(String content, float score, String comment) {
+}
+

--- a/src/main/java/com/example/grpcdemo/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/ReportServiceImpl.java
@@ -1,49 +1,69 @@
 package com.example.grpcdemo.service;
 
+import com.example.grpcdemo.entity.ReportEntity;
 import com.example.grpcdemo.proto.GenerateReportRequest;
 import com.example.grpcdemo.proto.GetReportRequest;
 import com.example.grpcdemo.proto.ReportResponse;
 import com.example.grpcdemo.proto.ReportServiceGrpc;
+import com.example.grpcdemo.repository.ReportRepository;
 import io.grpc.Status;
-
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
 
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 @GrpcService
 public class ReportServiceImpl extends ReportServiceGrpc.ReportServiceImplBase {
 
-    private final Map<String, ReportResponse> reportStore = new ConcurrentHashMap<>();
+    private final ReportRepository reportRepository;
+    private final AiEvaluationClient aiEvaluationClient;
+
+    public ReportServiceImpl(ReportRepository reportRepository, AiEvaluationClient aiEvaluationClient) {
+        this.reportRepository = reportRepository;
+        this.aiEvaluationClient = aiEvaluationClient;
+    }
 
     @Override
     public void generateReport(GenerateReportRequest request,
                                StreamObserver<ReportResponse> responseObserver) {
         String reportId = UUID.randomUUID().toString();
-        ReportResponse response = ReportResponse.newBuilder()
-                .setReportId(reportId)
-                .setInterviewId(request.getInterviewId())
-                .setContent("Report placeholder")
-                .setScore(0)
-                .setEvaluatorComment("")
-                .setCreatedAt(System.currentTimeMillis())
-                .build();
-        reportStore.put(reportId, response);
-        responseObserver.onNext(response);
-        responseObserver.onCompleted();
+        try {
+            EvaluationResult result = aiEvaluationClient.evaluate(request.getInterviewId());
+            ReportEntity entity = new ReportEntity(
+                    reportId,
+                    request.getInterviewId(),
+                    result.content(),
+                    result.score(),
+                    result.comment(),
+                    System.currentTimeMillis());
+            reportRepository.save(entity);
+            responseObserver.onNext(toResponse(entity));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            responseObserver.onError(Status.INTERNAL.withDescription("Failed to generate report").asRuntimeException());
+        }
     }
 
     @Override
     public void getReport(GetReportRequest request,
                           StreamObserver<ReportResponse> responseObserver) {
-        ReportResponse response = reportStore.get(request.getReportId());
-        if (response == null) {
-            responseObserver.onError(Status.NOT_FOUND.withDescription("Report not found").asRuntimeException());
-            return;
-        }
-        responseObserver.onNext(response);
-        responseObserver.onCompleted();
+        reportRepository.findById(request.getReportId())
+                .map(this::toResponse)
+                .ifPresentOrElse(response -> {
+                    responseObserver.onNext(response);
+                    responseObserver.onCompleted();
+                }, () -> responseObserver.onError(
+                        Status.NOT_FOUND.withDescription("Report not found").asRuntimeException()));
+    }
+
+    private ReportResponse toResponse(ReportEntity entity) {
+        return ReportResponse.newBuilder()
+                .setReportId(entity.getReportId())
+                .setInterviewId(entity.getInterviewId())
+                .setContent(entity.getContent())
+                .setScore(entity.getScore())
+                .setEvaluatorComment(entity.getEvaluatorComment())
+                .setCreatedAt(entity.getCreatedAt())
+                .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,16 @@ server:
 grpc:
   server:
     port: 9091   # gRPC 服务端口，BloomRPC 就连 localhost:9091
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:reports;DB_CLOSE_DELAY=-1
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect

--- a/src/test/java/com/example/grpcdemo/service/ReportServiceImplTest.java
+++ b/src/test/java/com/example/grpcdemo/service/ReportServiceImplTest.java
@@ -1,0 +1,84 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.entity.ReportEntity;
+import com.example.grpcdemo.proto.GenerateReportRequest;
+import com.example.grpcdemo.proto.ReportResponse;
+import com.example.grpcdemo.repository.ReportRepository;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class ReportServiceImplTest {
+
+    private ReportRepository reportRepository;
+    private AiEvaluationClient aiEvaluationClient;
+    private ReportServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        reportRepository = Mockito.mock(ReportRepository.class);
+        aiEvaluationClient = Mockito.mock(AiEvaluationClient.class);
+        service = new ReportServiceImpl(reportRepository, aiEvaluationClient);
+    }
+
+    @Test
+    void generateReport_persistsEntity() {
+        when(aiEvaluationClient.evaluate("int1"))
+                .thenReturn(new EvaluationResult("content", 4.5f, "good"));
+        TestObserver observer = new TestObserver();
+
+        service.generateReport(GenerateReportRequest.newBuilder().setInterviewId("int1").build(), observer);
+
+        assertNull(observer.error);
+        assertNotNull(observer.value);
+        ArgumentCaptor<ReportEntity> captor = ArgumentCaptor.forClass(ReportEntity.class);
+        verify(reportRepository).save(captor.capture());
+        ReportEntity saved = captor.getValue();
+        assertEquals(observer.value.getReportId(), saved.getReportId());
+        assertEquals("int1", saved.getInterviewId());
+        assertEquals("content", saved.getContent());
+        assertEquals(4.5f, saved.getScore());
+        assertEquals("good", saved.getEvaluatorComment());
+    }
+
+    @Test
+    void generateReport_handlesEvaluationFailure() {
+        when(aiEvaluationClient.evaluate(anyString())).thenThrow(new RuntimeException("fail"));
+        TestObserver observer = new TestObserver();
+
+        service.generateReport(GenerateReportRequest.newBuilder().setInterviewId("int1").build(), observer);
+
+        assertNotNull(observer.error);
+        assertEquals(Status.Code.INTERNAL, Status.fromThrowable(observer.error).getCode());
+        verify(reportRepository, never()).save(any());
+    }
+
+    private static class TestObserver implements StreamObserver<ReportResponse> {
+        ReportResponse value;
+        Throwable error;
+
+        @Override
+        public void onNext(ReportResponse value) {
+            this.value = value;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            this.error = t;
+        }
+
+        @Override
+        public void onCompleted() {
+            // no-op
+        }
+    }
+}
+

--- a/src/test/java/com/example/grpcdemo/service/ReportServiceIntegrationTest.java
+++ b/src/test/java/com/example/grpcdemo/service/ReportServiceIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.entity.ReportEntity;
+import com.example.grpcdemo.proto.GenerateReportRequest;
+import com.example.grpcdemo.proto.GetReportRequest;
+import com.example.grpcdemo.proto.ReportResponse;
+import com.example.grpcdemo.repository.ReportRepository;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class ReportServiceIntegrationTest {
+
+    @Autowired
+    private ReportServiceImpl service;
+
+    @Autowired
+    private ReportRepository repository;
+
+    @MockBean
+    private AiEvaluationClient aiEvaluationClient;
+
+    @Test
+    void generateReport_persistsToDatabase() {
+        when(aiEvaluationClient.evaluate("int1"))
+                .thenReturn(new EvaluationResult("content", 5.0f, "nice"));
+
+        TestObserver observer = new TestObserver();
+        service.generateReport(GenerateReportRequest.newBuilder().setInterviewId("int1").build(), observer);
+
+        assertNotNull(observer.value);
+        Optional<ReportEntity> entity = repository.findById(observer.value.getReportId());
+        assertTrue(entity.isPresent());
+        assertEquals("content", entity.get().getContent());
+
+        TestObserver getObserver = new TestObserver();
+        service.getReport(GetReportRequest.newBuilder().setReportId(observer.value.getReportId()).build(), getObserver);
+        assertEquals("content", getObserver.value.getContent());
+    }
+
+    @Test
+    void getReport_notFoundReturnsError() {
+        TestObserver observer = new TestObserver();
+        service.getReport(GetReportRequest.newBuilder().setReportId("missing").build(), observer);
+        assertNotNull(observer.error);
+        assertEquals(Status.Code.NOT_FOUND, Status.fromThrowable(observer.error).getCode());
+    }
+
+    private static class TestObserver implements StreamObserver<ReportResponse> {
+        ReportResponse value;
+        Throwable error;
+
+        @Override
+        public void onNext(ReportResponse value) {
+            this.value = value;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            this.error = t;
+        }
+
+        @Override
+        public void onCompleted() {
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- persist generated reports using JPA/H2
- fetch AI evaluation results to populate report fields
- add unit and integration tests for persistence and error handling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c21d8755708331ac4041b0aa0e6e04