### PR TITLE
Use hashed passwords and JWT tokens in auth service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,19 @@
             <version>${protobuf.version}</version>
         </dependency>
 
+        <!-- Password hashing -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+
+        <!-- JWT generation -->
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>4.4.0</version>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
@@ -4,9 +4,15 @@ import com.example.grpcdemo.proto.AuthServiceGrpc;
 import com.example.grpcdemo.proto.LoginRequest;
 import com.example.grpcdemo.proto.RegisterUserRequest;
 import com.example.grpcdemo.proto.UserResponse;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -15,11 +21,14 @@ import java.util.concurrent.ConcurrentHashMap;
 public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
 
     private final Map<String, RegisteredUser> userStore = new ConcurrentHashMap<>();
+    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    private final Algorithm jwtAlgorithm = Algorithm.HMAC256("secret-key");
 
     @Override
     public void registerUser(RegisterUserRequest request, StreamObserver<UserResponse> responseObserver) {
         String userId = UUID.randomUUID().toString();
-        RegisteredUser user = new RegisteredUser(userId, request.getUsername(), request.getPassword(), request.getRole());
+        String hashedPassword = passwordEncoder.encode(request.getPassword());
+        RegisteredUser user = new RegisteredUser(userId, request.getUsername(), hashedPassword, request.getRole());
         userStore.put(request.getUsername(), user);
 
         UserResponse response = UserResponse.newBuilder()
@@ -34,23 +43,26 @@ public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
     @Override
     public void loginUser(LoginRequest request, StreamObserver<UserResponse> responseObserver) {
         RegisteredUser user = userStore.get(request.getUsername());
-        if (user != null && user.password().equals(request.getPassword())) {
+        if (user != null && passwordEncoder.matches(request.getPassword(), user.hashedPassword())) {
+            String token = JWT.create()
+                    .withSubject(user.userId())
+                    .withClaim("username", user.username())
+                    .withClaim("role", user.role())
+                    .withExpiresAt(Date.from(Instant.now().plusSeconds(3600)))
+                    .sign(jwtAlgorithm);
+
             UserResponse response = UserResponse.newBuilder()
                     .setUserId(user.userId())
                     .setUsername(user.username())
                     .setRole(user.role())
+                    .setAccessToken(token)
                     .build();
             responseObserver.onNext(response);
             responseObserver.onCompleted();
         } else {
-            responseObserver.onNext(UserResponse.newBuilder()
-                    .setUserId("")
-                    .setUsername("Invalid")
-                    .setRole("Unknown")
-                    .build());
-            responseObserver.onCompleted();
+            responseObserver.onError(Status.UNAUTHENTICATED.asRuntimeException());
         }
     }
 
-    private record RegisteredUser(String userId, String username, String password, String role) {}
+    private record RegisteredUser(String userId, String username, String hashedPassword, String role) {}
 }

--- a/src/main/proto/auth.proto
+++ b/src/main/proto/auth.proto
@@ -26,4 +26,5 @@ message UserResponse {
   string userId = 1;
   string username = 2;
   string role = 3;
+  string accessToken = 4;
 }


### PR DESCRIPTION
## Summary
- Hash user passwords with BCrypt before storage and verify during login
- Issue JWT access tokens on successful login and signal UNAUTHENTICATED on failures
- Extend auth.proto and add dependencies for password hashing and JWT

## Testing
- `./mvnw -q test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68c21d8189588331bc4457f0b316b5e4