### PR TITLE
feat: secure auth with bcrypt and jwt

### DIFF
--- a/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
@@ -4,15 +4,11 @@ import com.example.grpcdemo.proto.AuthServiceGrpc;
 import com.example.grpcdemo.proto.LoginRequest;
 import com.example.grpcdemo.proto.RegisterUserRequest;
 import com.example.grpcdemo.proto.UserResponse;
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCrypt;
 
-import java.time.Instant;
-import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,13 +17,11 @@ import java.util.concurrent.ConcurrentHashMap;
 public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
 
     private final Map<String, RegisteredUser> userStore = new ConcurrentHashMap<>();
-    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-    private final Algorithm jwtAlgorithm = Algorithm.HMAC256("secret-key");
 
     @Override
     public void registerUser(RegisterUserRequest request, StreamObserver<UserResponse> responseObserver) {
         String userId = UUID.randomUUID().toString();
-        String hashedPassword = passwordEncoder.encode(request.getPassword());
+        String hashedPassword = BCrypt.hashpw(request.getPassword(), BCrypt.gensalt());
         RegisteredUser user = new RegisteredUser(userId, request.getUsername(), hashedPassword, request.getRole());
         userStore.put(request.getUsername(), user);
 
@@ -43,13 +37,8 @@ public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
     @Override
     public void loginUser(LoginRequest request, StreamObserver<UserResponse> responseObserver) {
         RegisteredUser user = userStore.get(request.getUsername());
-        if (user != null && passwordEncoder.matches(request.getPassword(), user.hashedPassword())) {
-            String token = JWT.create()
-                    .withSubject(user.userId())
-                    .withClaim("username", user.username())
-                    .withClaim("role", user.role())
-                    .withExpiresAt(Date.from(Instant.now().plusSeconds(3600)))
-                    .sign(jwtAlgorithm);
+        if (user != null && BCrypt.checkpw(request.getPassword(), user.hashedPassword())) {
+            String token = JwtUtil.generateToken(user.userId(), user.username(), user.role());
 
             UserResponse response = UserResponse.newBuilder()
                     .setUserId(user.userId())

--- a/src/main/java/com/example/grpcdemo/service/JwtUtil.java
+++ b/src/main/java/com/example/grpcdemo/service/JwtUtil.java
@@ -1,0 +1,36 @@
+package com.example.grpcdemo.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.JWTVerifier;
+
+import java.time.Instant;
+import java.util.Date;
+
+/**
+ * Utility for generating and validating JSON Web Tokens.
+ */
+public final class JwtUtil {
+
+    private static final String SECRET_KEY = "secret-key";
+    private static final Algorithm ALGORITHM = Algorithm.HMAC256(SECRET_KEY);
+    private static final JWTVerifier VERIFIER = JWT.require(ALGORITHM).build();
+
+    private JwtUtil() {
+    }
+
+    public static String generateToken(String userId, String username, String role) {
+        return JWT.create()
+                .withSubject(userId)
+                .withClaim("username", username)
+                .withClaim("role", role)
+                .withExpiresAt(Date.from(Instant.now().plusSeconds(3600)))
+                .sign(ALGORITHM);
+    }
+
+    public static DecodedJWT validateToken(String token) {
+        return VERIFIER.verify(token);
+    }
+}
+


### PR DESCRIPTION
## Summary
- hash user passwords with BCrypt during registration
- verify credentials with `BCrypt.checkpw` and return UNAUTHENTICATED on failure
- add JwtUtil for issuing and validating JWTs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a43c4d5c8331b77112dc3e23f09c