### PR TITLE
Persist auth users with hashed passwords

### DIFF
--- a/src/main/java/com/example/grpcdemo/config/SecurityConfig.java
+++ b/src/main/java/com/example/grpcdemo/config/SecurityConfig.java
@@ -1,0 +1,18 @@
+package com.example.grpcdemo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Security-related configuration beans.
+ */
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/grpcdemo/entity/UserAccountEntity.java
+++ b/src/main/java/com/example/grpcdemo/entity/UserAccountEntity.java
@@ -1,0 +1,68 @@
+package com.example.grpcdemo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * JPA entity representing a registered user account.
+ */
+@Entity
+@Table(name = "user_accounts")
+public class UserAccountEntity {
+
+    @Id
+    private String userId;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    @Column(nullable = false)
+    private String role;
+
+    public UserAccountEntity() {
+    }
+
+    public UserAccountEntity(String userId, String username, String passwordHash, String role) {
+        this.userId = userId;
+        this.username = username;
+        this.passwordHash = passwordHash;
+        this.role = role;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/repository/UserAccountRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/UserAccountRepository.java
@@ -1,0 +1,14 @@
+package com.example.grpcdemo.repository;
+
+import com.example.grpcdemo.entity.UserAccountEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * Repository for {@link UserAccountEntity} records.
+ */
+public interface UserAccountRepository extends JpaRepository<UserAccountEntity, String> {
+
+    Optional<UserAccountEntity> findByUsername(String username);
+}

--- a/src/test/java/com/example/grpcdemo/service/AuthServiceImplTest.java
+++ b/src/test/java/com/example/grpcdemo/service/AuthServiceImplTest.java
@@ -1,0 +1,119 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.entity.UserAccountEntity;
+import com.example.grpcdemo.proto.LoginRequest;
+import com.example.grpcdemo.proto.RegisterUserRequest;
+import com.example.grpcdemo.proto.UserResponse;
+import com.example.grpcdemo.repository.UserAccountRepository;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class AuthServiceImplTest {
+
+    private UserAccountRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+    private AuthServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = Mockito.mock(UserAccountRepository.class);
+        passwordEncoder = new BCryptPasswordEncoder();
+        service = new AuthServiceImpl(userRepository, passwordEncoder);
+    }
+
+    @Test
+    void registerUser_persistsHashedPassword() {
+        when(userRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        TestObserver observer = new TestObserver();
+
+        RegisterUserRequest request = RegisterUserRequest.newBuilder()
+                .setUsername("alice")
+                .setPassword("pa55w0rd")
+                .setRole("ADMIN")
+                .build();
+        service.registerUser(request, observer);
+
+        assertNull(observer.error);
+        assertNotNull(observer.value);
+        assertEquals("alice", observer.value.getUsername());
+        ArgumentCaptor<UserAccountEntity> captor = ArgumentCaptor.forClass(UserAccountEntity.class);
+        verify(userRepository).save(captor.capture());
+        UserAccountEntity saved = captor.getValue();
+        assertEquals(observer.value.getUserId(), saved.getUserId());
+        assertEquals("alice", saved.getUsername());
+        assertEquals("ADMIN", saved.getRole());
+        assertNotEquals("pa55w0rd", saved.getPasswordHash());
+        assertTrue(passwordEncoder.matches("pa55w0rd", saved.getPasswordHash()));
+    }
+
+    @Test
+    void loginUser_returnsTokenWhenPasswordMatches() {
+        String hashed = passwordEncoder.encode("secret");
+        when(userRepository.findByUsername("alice"))
+                .thenReturn(Optional.of(new UserAccountEntity("id-1", "alice", hashed, "ADMIN")));
+        TestObserver observer = new TestObserver();
+
+        LoginRequest request = LoginRequest.newBuilder()
+                .setUsername("alice")
+                .setPassword("secret")
+                .build();
+        service.loginUser(request, observer);
+
+        assertNull(observer.error);
+        assertNotNull(observer.value);
+        assertEquals("id-1", observer.value.getUserId());
+        assertEquals("alice", observer.value.getUsername());
+        assertEquals("ADMIN", observer.value.getRole());
+        assertFalse(observer.value.getAccessToken().isEmpty());
+    }
+
+    @Test
+    void loginUser_returnsUnauthenticatedWhenPasswordDoesNotMatch() {
+        String hashed = passwordEncoder.encode("right-password");
+        when(userRepository.findByUsername("alice"))
+                .thenReturn(Optional.of(new UserAccountEntity("id-1", "alice", hashed, "ADMIN")));
+        TestObserver observer = new TestObserver();
+
+        LoginRequest request = LoginRequest.newBuilder()
+                .setUsername("alice")
+                .setPassword("wrong")
+                .build();
+        service.loginUser(request, observer);
+
+        assertNull(observer.value);
+        assertNotNull(observer.error);
+        assertEquals(Status.Code.UNAUTHENTICATED, Status.fromThrowable(observer.error).getCode());
+    }
+
+    private static class TestObserver implements StreamObserver<UserResponse> {
+        private UserResponse value;
+        private Throwable error;
+
+        @Override
+        public void onNext(UserResponse value) {
+            this.value = value;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            this.error = t;
+        }
+
+        @Override
+        public void onCompleted() {
+            // no-op
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the in-memory auth store with a JPA-backed repository that stores BCrypt-hashed passwords
- expose a PasswordEncoder bean to support hashing
- add unit tests covering successful and failed login attempts using hashed credentials

## Testing
- `mvn test` *(fails: unable to download Spring Boot parent POM because the Maven Central repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfcc151a48833188b16b7bf10bd8ed