### PR TITLE
Improve gRPC error handling in notification service

### DIFF
--- a/src/main/java/com/example/grpcdemo/service/NotificationServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/NotificationServiceImpl.java
@@ -38,8 +38,20 @@ public class NotificationServiceImpl extends NotificationServiceGrpc.Notificatio
             responseObserver.onNext(response);
             responseObserver.onCompleted();
         } catch (MailException e) {
-            logger.error("Failed to send invitation email to {}", request.getEmail(), e);
-            responseObserver.onError(Status.INTERNAL.asRuntimeException());
+            String baseMessage = String.format("Failed to send invitation email to %s with subject '%s'",
+                    request.getEmail(), request.getSubject());
+            String detailedMessage = baseMessage;
+            if (e.getMessage() != null && !e.getMessage().isBlank()) {
+                detailedMessage = baseMessage + ". Cause: " + e.getMessage();
+            }
+
+            logger.error("Failed to send invitation email to {} with subject '{}'. Cause: {}",
+                    request.getEmail(), request.getSubject(), e.getMessage(), e);
+            responseObserver.onError(
+                    Status.INTERNAL
+                            .withDescription(detailedMessage)
+                            .withCause(e)
+                            .asRuntimeException());
         }
     }
 }

--- a/src/test/java/com/example/grpcdemo/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/example/grpcdemo/service/NotificationServiceImplTest.java
@@ -1,0 +1,80 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.proto.SendInvitationRequest;
+import com.example.grpcdemo.proto.SendInvitationResponse;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceImplTest {
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private StreamObserver<SendInvitationResponse> responseObserver;
+
+    @InjectMocks
+    private NotificationServiceImpl notificationService;
+
+    private SendInvitationRequest request;
+
+    @BeforeEach
+    void setUp() {
+        request = SendInvitationRequest.newBuilder()
+                .setEmail("candidate@example.com")
+                .setSubject("Interview Invitation")
+                .setContent("Please join us for an interview.")
+                .build();
+    }
+
+    @Test
+    void sendInvitation_deliversSuccessResponseWhenMailSent() {
+        notificationService.sendInvitation(request, responseObserver);
+
+        ArgumentCaptor<SendInvitationResponse> responseCaptor = ArgumentCaptor.forClass(SendInvitationResponse.class);
+        verify(mailSender).send(any(SimpleMailMessage.class));
+        verify(responseObserver).onNext(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().getSuccess());
+        verify(responseObserver).onCompleted();
+        verify(responseObserver, never()).onError(any());
+    }
+
+    @Test
+    void sendInvitation_propagatesGrpcErrorWhenMailFails() {
+        MailSendException mailException = new MailSendException("SMTP server not available");
+        doThrow(mailException).when(mailSender).send(any(SimpleMailMessage.class));
+
+        notificationService.sendInvitation(request, responseObserver);
+
+        verify(responseObserver, never()).onNext(any());
+        verify(responseObserver, never()).onCompleted();
+
+        ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(responseObserver).onError(errorCaptor.capture());
+
+        Throwable thrown = errorCaptor.getValue();
+        assertTrue(thrown instanceof StatusRuntimeException);
+
+        Status status = Status.fromThrowable(thrown);
+        assertEquals(Status.Code.INTERNAL, status.getCode());
+        assertEquals("Failed to send invitation email to candidate@example.com with subject 'Interview Invitation'. Cause: SMTP server not available",
+                status.getDescription());
+        assertSame(mailException, status.getCause());
+    }
+}


### PR DESCRIPTION
## Summary
- enrich NotificationServiceImpl gRPC error handling by logging detailed failure context and surfacing a descriptive INTERNAL status to clients
- add unit tests covering successful and failing invitation deliveries

## Testing
- mvn test *(fails: unable to resolve dependencies because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd005b77c8331b4fe43e2d33b5b37