### PR TITLE
Persist and synthesize reports from interview context

### DIFF
--- a/src/main/java/com/example/grpcdemo/service/InterviewNotFoundException.java
+++ b/src/main/java/com/example/grpcdemo/service/InterviewNotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.grpcdemo.service;
+
+/**
+ * Exception thrown when attempting to generate a report for an interview
+ * that cannot be located in the persistence layer.
+ */
+public class InterviewNotFoundException extends RuntimeException {
+
+    public InterviewNotFoundException(String interviewId) {
+        super("Interview " + interviewId + " not found");
+    }
+}

--- a/src/main/java/com/example/grpcdemo/service/ReportGenerator.java
+++ b/src/main/java/com/example/grpcdemo/service/ReportGenerator.java
@@ -1,0 +1,103 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.entity.ReportEntity;
+import com.example.grpcdemo.model.Candidate;
+import com.example.grpcdemo.model.Interview;
+import com.example.grpcdemo.model.Job;
+import com.example.grpcdemo.repository.CandidateRepository;
+import com.example.grpcdemo.repository.InterviewRepository;
+import com.example.grpcdemo.repository.JobRepository;
+import com.example.grpcdemo.repository.ReportRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Coordinates gathering interview context, invoking the AI evaluation and
+ * storing the resulting report content.
+ */
+@Service
+public class ReportGenerator {
+
+    private final ReportRepository reportRepository;
+    private final InterviewRepository interviewRepository;
+    private final CandidateRepository candidateRepository;
+    private final JobRepository jobRepository;
+    private final AiEvaluationClient aiEvaluationClient;
+
+    public ReportGenerator(ReportRepository reportRepository,
+                           InterviewRepository interviewRepository,
+                           CandidateRepository candidateRepository,
+                           JobRepository jobRepository,
+                           AiEvaluationClient aiEvaluationClient) {
+        this.reportRepository = reportRepository;
+        this.interviewRepository = interviewRepository;
+        this.candidateRepository = candidateRepository;
+        this.jobRepository = jobRepository;
+        this.aiEvaluationClient = aiEvaluationClient;
+    }
+
+    /**
+     * Generate a report for the supplied interview and persist it.
+     *
+     * @param interviewId the interview identifier
+     * @return the persisted report entity
+     */
+    public ReportEntity generateAndStore(String interviewId) {
+        Interview interview = interviewRepository.findById(interviewId)
+                .orElseThrow(() -> new InterviewNotFoundException(interviewId));
+
+        Candidate candidate = Optional.ofNullable(interview.getCandidateId())
+                .flatMap(candidateRepository::findById)
+                .orElse(null);
+        Job job = Optional.ofNullable(interview.getJobId())
+                .flatMap(jobRepository::findById)
+                .orElse(null);
+
+        EvaluationResult evaluation = aiEvaluationClient.evaluate(interviewId);
+        String comment = evaluation.comment() != null ? evaluation.comment() : "";
+        ReportEntity entity = new ReportEntity(
+                UUID.randomUUID().toString(),
+                interviewId,
+                buildContent(interview, candidate, job, evaluation),
+                evaluation.score(),
+                comment,
+                System.currentTimeMillis());
+        return reportRepository.save(entity);
+    }
+
+    private String buildContent(Interview interview, Candidate candidate, Job job, EvaluationResult evaluation) {
+        String lineSeparator = System.lineSeparator();
+        StringBuilder builder = new StringBuilder();
+        builder.append("Interview Report").append(lineSeparator);
+        builder.append("Candidate: ")
+                .append(candidate != null && candidate.getName() != null ? candidate.getName() : "Unknown candidate")
+                .append(lineSeparator);
+        if (candidate != null && candidate.getEmail() != null && !candidate.getEmail().isBlank()) {
+            builder.append("Email: ").append(candidate.getEmail()).append(lineSeparator);
+        }
+        builder.append("Job: ")
+                .append(job != null && job.getJobTitle() != null ? job.getJobTitle() : "Unknown role")
+                .append(lineSeparator);
+        builder.append("Scheduled: ")
+                .append(interview.getScheduledTime() != null && !interview.getScheduledTime().isBlank()
+                        ? interview.getScheduledTime() : "unscheduled time")
+                .append(lineSeparator);
+        builder.append("Status: ")
+                .append(interview.getStatus() != null ? interview.getStatus() : "UNKNOWN")
+                .append(lineSeparator).append(lineSeparator);
+        builder.append("AI Summary:").append(lineSeparator);
+        builder.append(evaluation.content()).append(lineSeparator);
+        if (evaluation.comment() != null && !evaluation.comment().isBlank()) {
+            builder.append(lineSeparator)
+                    .append("Evaluator Comment: ")
+                    .append(evaluation.comment())
+                    .append(lineSeparator);
+        }
+        builder.append("Score: ")
+                .append(String.format(Locale.US, "%.2f", evaluation.score()));
+        return builder.toString();
+    }
+}

--- a/src/test/java/com/example/grpcdemo/service/ReportGeneratorTest.java
+++ b/src/test/java/com/example/grpcdemo/service/ReportGeneratorTest.java
@@ -1,0 +1,103 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.entity.ReportEntity;
+import com.example.grpcdemo.model.Candidate;
+import com.example.grpcdemo.model.Interview;
+import com.example.grpcdemo.model.Job;
+import com.example.grpcdemo.repository.CandidateRepository;
+import com.example.grpcdemo.repository.InterviewRepository;
+import com.example.grpcdemo.repository.JobRepository;
+import com.example.grpcdemo.repository.ReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ReportGeneratorTest {
+
+    private ReportRepository reportRepository;
+    private InterviewRepository interviewRepository;
+    private CandidateRepository candidateRepository;
+    private JobRepository jobRepository;
+    private AiEvaluationClient aiEvaluationClient;
+    private ReportGenerator generator;
+
+    @BeforeEach
+    void setUp() {
+        reportRepository = mock(ReportRepository.class);
+        interviewRepository = mock(InterviewRepository.class);
+        candidateRepository = mock(CandidateRepository.class);
+        jobRepository = mock(JobRepository.class);
+        aiEvaluationClient = mock(AiEvaluationClient.class);
+        generator = new ReportGenerator(reportRepository, interviewRepository, candidateRepository, jobRepository, aiEvaluationClient);
+    }
+
+    @Test
+    void generateAndStore_buildsContentFromContext() {
+        Interview interview = new Interview();
+        interview.setId("int1");
+        interview.setCandidateId("cand1");
+        interview.setJobId("job1");
+        interview.setScheduledTime("2024-04-20T12:00:00Z");
+        interview.setStatus("COMPLETED");
+        when(interviewRepository.findById("int1")).thenReturn(Optional.of(interview));
+
+        Candidate candidate = new Candidate();
+        candidate.setId("cand1");
+        candidate.setName("Jane Doe");
+        candidate.setEmail("jane@example.com");
+        when(candidateRepository.findById("cand1")).thenReturn(Optional.of(candidate));
+
+        Job job = new Job();
+        job.setId("job1");
+        job.setJobTitle("Backend Developer");
+        when(jobRepository.findById("job1")).thenReturn(Optional.of(job));
+
+        when(aiEvaluationClient.evaluate("int1"))
+                .thenReturn(new EvaluationResult("Strong communication skills", 0.82f, "Great potential"));
+        when(reportRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ReportEntity entity = generator.generateAndStore("int1");
+
+        assertNotNull(entity.getReportId());
+        assertEquals("int1", entity.getInterviewId());
+        assertEquals(0.82f, entity.getScore());
+        assertEquals("Great potential", entity.getEvaluatorComment());
+        assertTrue(entity.getContent().contains("Jane Doe"));
+        assertTrue(entity.getContent().contains("Backend Developer"));
+        assertTrue(entity.getContent().contains("Strong communication skills"));
+        assertTrue(entity.getContent().contains("Score: 0.82"));
+        assertTrue(entity.getCreatedAt() > 0);
+    }
+
+    @Test
+    void generateAndStore_missingInterviewThrowsException() {
+        when(interviewRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThrows(InterviewNotFoundException.class, () -> generator.generateAndStore("missing"));
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    void generateAndStore_handlesMissingCandidateAndJob() {
+        Interview interview = new Interview();
+        interview.setId("int2");
+        interview.setScheduledTime("2024-04-25T08:30:00Z");
+        interview.setStatus("COMPLETED");
+        when(interviewRepository.findById("int2")).thenReturn(Optional.of(interview));
+
+        when(aiEvaluationClient.evaluate("int2"))
+                .thenReturn(new EvaluationResult("Average performance", 0.5f, "Needs improvement"));
+        when(reportRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ReportEntity entity = generator.generateAndStore("int2");
+
+        assertTrue(entity.getContent().contains("Unknown candidate"));
+        assertTrue(entity.getContent().contains("Unknown role"));
+        assertTrue(entity.getContent().contains("Average performance"));
+    }
+}

--- a/src/test/java/com/example/grpcdemo/service/ReportServiceIntegrationTest.java
+++ b/src/test/java/com/example/grpcdemo/service/ReportServiceIntegrationTest.java
@@ -1,9 +1,15 @@
 package com.example.grpcdemo.service;
 
 import com.example.grpcdemo.entity.ReportEntity;
+import com.example.grpcdemo.model.Candidate;
+import com.example.grpcdemo.model.Interview;
+import com.example.grpcdemo.model.Job;
 import com.example.grpcdemo.proto.GenerateReportRequest;
 import com.example.grpcdemo.proto.GetReportRequest;
 import com.example.grpcdemo.proto.ReportResponse;
+import com.example.grpcdemo.repository.CandidateRepository;
+import com.example.grpcdemo.repository.InterviewRepository;
+import com.example.grpcdemo.repository.JobRepository;
 import com.example.grpcdemo.repository.ReportRepository;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
@@ -27,16 +33,50 @@ class ReportServiceIntegrationTest {
     @Autowired
     private ReportRepository repository;
 
+    @Autowired
+    private CandidateRepository candidateRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    private InterviewRepository interviewRepository;
+
+    @Autowired
+    private ReportGenerator reportGenerator;
+
     @MockBean
     private AiEvaluationClient aiEvaluationClient;
 
     @AfterEach
     void cleanDatabase() {
         repository.deleteAll();
+        interviewRepository.deleteAll();
+        candidateRepository.deleteAll();
+        jobRepository.deleteAll();
     }
 
     @Test
     void generateReport_persistsToDatabase() {
+        Candidate candidate = new Candidate();
+        candidate.setId("cand1");
+        candidate.setName("Ada Lovelace");
+        candidate.setEmail("ada@example.com");
+        candidateRepository.save(candidate);
+
+        Job job = new Job();
+        job.setId("job1");
+        job.setJobTitle("Platform Engineer");
+        jobRepository.save(job);
+
+        Interview interview = new Interview();
+        interview.setId("int1");
+        interview.setCandidateId("cand1");
+        interview.setJobId("job1");
+        interview.setScheduledTime("2024-05-01T09:00:00Z");
+        interview.setStatus("COMPLETED");
+        interviewRepository.save(interview);
+
         when(aiEvaluationClient.evaluate("int1"))
                 .thenReturn(new EvaluationResult("content", 5.0f, "nice"));
 
@@ -46,15 +86,36 @@ class ReportServiceIntegrationTest {
         assertNotNull(observer.value);
         Optional<ReportEntity> entity = repository.findById(observer.value.getReportId());
         assertTrue(entity.isPresent());
-        assertEquals("content", entity.get().getContent());
+        assertTrue(entity.get().getContent().contains("Ada Lovelace"));
+        assertTrue(entity.get().getContent().contains("Platform Engineer"));
+        assertTrue(entity.get().getContent().contains("content"));
 
         TestObserver getObserver = new TestObserver();
         service.getReport(GetReportRequest.newBuilder().setReportId(observer.value.getReportId()).build(), getObserver);
-        assertEquals("content", getObserver.value.getContent());
+        assertTrue(getObserver.value.getContent().contains("content"));
+        assertTrue(getObserver.value.getContent().contains("Ada Lovelace"));
     }
 
     @Test
     void reportIsRetrievableAfterServiceRecreation() {
+        Candidate candidate = new Candidate();
+        candidate.setId("cand2");
+        candidate.setName("Grace Hopper");
+        candidateRepository.save(candidate);
+
+        Job job = new Job();
+        job.setId("job2");
+        job.setJobTitle("Backend Developer");
+        jobRepository.save(job);
+
+        Interview interview = new Interview();
+        interview.setId("int2");
+        interview.setCandidateId("cand2");
+        interview.setJobId("job2");
+        interview.setScheduledTime("2024-05-02T10:30:00Z");
+        interview.setStatus("COMPLETED");
+        interviewRepository.save(interview);
+
         when(aiEvaluationClient.evaluate("int2"))
                 .thenReturn(new EvaluationResult("analysis", 4.2f, "solid candidate"));
 
@@ -62,7 +123,7 @@ class ReportServiceIntegrationTest {
         service.generateReport(GenerateReportRequest.newBuilder().setInterviewId("int2").build(), observer);
 
         assertNotNull(observer.value);
-        ReportServiceImpl newInstance = new ReportServiceImpl(repository, aiEvaluationClient);
+        ReportServiceImpl newInstance = new ReportServiceImpl(repository, reportGenerator);
         TestObserver secondObserver = new TestObserver();
         newInstance.getReport(GetReportRequest.newBuilder()
                 .setReportId(observer.value.getReportId())
@@ -70,7 +131,7 @@ class ReportServiceIntegrationTest {
 
         assertNull(secondObserver.error);
         assertNotNull(secondObserver.value);
-        assertEquals("analysis", secondObserver.value.getContent());
+        assertTrue(secondObserver.value.getContent().contains("analysis"));
         assertEquals(4.2f, secondObserver.value.getScore());
         assertEquals("solid candidate", secondObserver.value.getEvaluatorComment());
     }


### PR DESCRIPTION
## Summary
- introduce a `ReportGenerator` service that assembles report content from interview, candidate, and job data together with AI evaluation output before persisting via JPA
- update the gRPC report service and RabbitMQ consumer to delegate to the generator, surfacing NOT_FOUND for missing interviews and removing in-memory storage
- extend unit and integration coverage around report generation, retrieval, and missing-report handling with the persistent backend

## Testing
- `mvn test` *(fails: unable to reach Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd540c0188331882dbdf1d89d95e8