### PR TITLE
feat: add auth verification flow and http gateway

### DIFF
--- a/MICROSERVICE_API.md
+++ b/MICROSERVICE_API.md
@@ -1,0 +1,84 @@
+# Microservice API Definitions
+
+## Domain Breakdown
+| 领域 | 核心职责 | 主要实体 |
+| --- | --- | --- |
+| 鉴权与用户管理 | 账户注册、登录、角色与权限（企业管理员、候选人等） | User, Role |
+| 企业与岗位管理 | 企业信息维护、岗位创建与发布、岗位状态管理 | Company, Job |
+| 候选人管理 | 简历解析、候选人信息维护、岗位与候选人关联 | Candidate, Resume |
+| 面试流程管理 | 面试题目生成、答题记录、进度追踪 | Interview, Question, Answer |
+| 报告生成与查看 | 面试结果汇总、评估报告生成、下载/分享 | Report |
+| 通知与消息服务 | 邀约邮件、面试提醒、系统通知 | EmailTemplate, Notification |
+| AI 服务接口 | 题目生成、语音转文字、答案评估 | AI Engine (外部/独立服务) |
+
+## Key Use Cases
+- 用户与权限：企业注册、候选人注册/登录、权限控制（企业端 vs 候选人端 vs 管理后台）
+- 岗位生命周期：创建岗位 → 编辑/发布 → 状态流转（招募中/已完成） → 删除
+- 候选人生命周期：简历上传与解析、候选人与岗位关联、状态管理（未面试/面试中/已完成）
+- 面试流程：面试邀请（邮件 + 链接 + 初始密码）、候选人登录 → 答题说明 → 智能出题 → 逐题作答 → 提交完成
+- 报告与决策：根据答题内容自动生成评估报告，企业端在线查看、下载或分享，招聘团队依据报告做出录用决策
+- 通知与消息：面试邀请、提醒、结果反馈等自动化通知，支持自定义模板、多语言输出
+- AI 能力支撑：简历信息提取、面试题目生成、语音识别、自动评估，统一以 API 形式对外提供服务
+
+## gRPC Interfaces
+
+### Auth Service
+- `rpc RequestVerificationCode(VerificationCodeRequest) returns (VerificationCodeResponse)`
+- `rpc RegisterUser(RegisterUserRequest) returns (UserResponse)`
+- `rpc LoginUser(LoginRequest) returns (UserResponse)`
+
+`VerificationCodeRequest` 字段：`email`, `role`
+
+`UserResponse` 字段：`userId`, `email`, `role`, `accessToken`, `refreshToken`
+
+#### HTTP Gateway（供前端使用）
+- 企业端：
+  - `POST /api/b/auth/send-code`
+  - `POST /api/b/auth/register`
+  - `POST /api/b/auth/login`
+- 工程师端：
+  - `POST /api/c/auth/send-code`
+  - `POST /api/c/auth/register`
+  - `POST /api/c/auth/login`
+
+### Job Service
+- `rpc CreateJob(CreateJobRequest) returns (JobResponse)`
+- `rpc GetJob(JobRequest) returns (JobResponse)`
+- `rpc ListJobs(ListJobsRequest) returns (ListJobsResponse)`
+
+### Candidate Service
+- `rpc CreateCandidate(CreateCandidateRequest) returns (CandidateResponse)`
+- `rpc GetCandidate(CandidateRequest) returns (CandidateResponse)`
+- `rpc ListCandidates(ListCandidatesRequest) returns (ListCandidatesResponse)`
+
+### Interview Service
+- `rpc ScheduleInterview(ScheduleInterviewRequest) returns (InterviewResponse)`
+- `rpc ConfirmInterview(ConfirmInterviewRequest) returns (InterviewResponse)`
+- `rpc GetInterviewsByCandidate(GetInterviewsByCandidateRequest) returns (InterviewsResponse)`
+- `rpc GetInterviewsByJob(GetInterviewsByJobRequest) returns (InterviewsResponse)`
+
+### Report Service
+- `rpc GenerateReport(GenerateReportRequest) returns (ReportResponse)`
+- `rpc GetReport(GetReportRequest) returns (ReportResponse)` — 若报告不存在返回 `NOT_FOUND`
+
+`ReportResponse` 字段：
+- `reportId`
+- `interviewId`
+- `content`
+- `score`
+- `evaluatorComment`
+- `createdAt`（毫秒级时间戳）
+
+### Notification Service
+- `rpc SendInvitation(SendInvitationRequest) returns (SendInvitationResponse)` — 发送面试邀约邮件
+
+`SendInvitationRequest` 字段：
+- `email`
+- `subject`
+- `content`
+
+`SendInvitationResponse` 字段：
+- `success`
+- `message`
+
+Each service maintains its own data store and communicates over gRPC to ensure loose coupling and scalability.

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,16 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
         <!-- gRPC Server -->
         <dependency>
             <groupId>net.devh</groupId>
@@ -45,6 +55,17 @@
             <groupId>net.devh</groupId>
             <artifactId>grpc-client-spring-boot-starter</artifactId>
             <version>2.15.0.RELEASE</version>
+        </dependency>
+
+        <!-- Mail support -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
         </dependency>
 
         <!-- Protobuf -->

--- a/src/main/java/com/example/grpcdemo/auth/AuthErrorCode.java
+++ b/src/main/java/com/example/grpcdemo/auth/AuthErrorCode.java
@@ -1,0 +1,39 @@
+package com.example.grpcdemo.auth;
+
+import io.grpc.Status;
+import org.springframework.http.HttpStatus;
+
+public enum AuthErrorCode {
+    INVALID_ROLE(Status.INVALID_ARGUMENT, HttpStatus.BAD_REQUEST, "无效的角色"),
+    INVALID_EMAIL(Status.INVALID_ARGUMENT, HttpStatus.BAD_REQUEST, "邮箱格式不正确"),
+    CODE_REQUEST_TOO_FREQUENT(Status.RESOURCE_EXHAUSTED, HttpStatus.TOO_MANY_REQUESTS, "验证码请求过于频繁"),
+    CODE_NOT_FOUND(Status.NOT_FOUND, HttpStatus.BAD_REQUEST, "验证码不存在或已被使用"),
+    CODE_EXPIRED(Status.DEADLINE_EXCEEDED, HttpStatus.BAD_REQUEST, "验证码已过期"),
+    CODE_MISMATCH(Status.PERMISSION_DENIED, HttpStatus.BAD_REQUEST, "验证码不匹配"),
+    USER_ALREADY_EXISTS(Status.ALREADY_EXISTS, HttpStatus.CONFLICT, "用户已存在"),
+    PASSWORD_TOO_WEAK(Status.INVALID_ARGUMENT, HttpStatus.BAD_REQUEST, "密码强度不足"),
+    INVALID_CREDENTIALS(Status.UNAUTHENTICATED, HttpStatus.UNAUTHORIZED, "邮箱或密码错误"),
+    INTERNAL_ERROR(Status.INTERNAL, HttpStatus.INTERNAL_SERVER_ERROR, "系统内部错误");
+
+    private final Status status;
+    private final HttpStatus httpStatus;
+    private final String defaultMessage;
+
+    AuthErrorCode(Status status, HttpStatus httpStatus, String defaultMessage) {
+        this.status = status;
+        this.httpStatus = httpStatus;
+        this.defaultMessage = defaultMessage;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/auth/AuthException.java
+++ b/src/main/java/com/example/grpcdemo/auth/AuthException.java
@@ -1,0 +1,20 @@
+package com.example.grpcdemo.auth;
+
+public class AuthException extends RuntimeException {
+
+    private final AuthErrorCode errorCode;
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode.getDefaultMessage());
+        this.errorCode = errorCode;
+    }
+
+    public AuthException(AuthErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public AuthErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/auth/AuthManager.java
+++ b/src/main/java/com/example/grpcdemo/auth/AuthManager.java
@@ -1,0 +1,167 @@
+package com.example.grpcdemo.auth;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+@Component
+public class AuthManager {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthManager.class);
+    private static final Duration CODE_TTL = Duration.ofMinutes(5);
+    private static final Duration RESEND_INTERVAL = Duration.ofMinutes(1);
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+
+    private final Map<String, UserAccount> userStore = new ConcurrentHashMap<>();
+    private final Map<String, VerificationCodeRecord> codeStore = new ConcurrentHashMap<>();
+    private final PasswordEncoder passwordEncoder;
+    private final SecureRandom random;
+    private final Clock clock;
+
+    public AuthManager() {
+        this(new BCryptPasswordEncoder(), new SecureRandom(), Clock.systemUTC());
+    }
+
+    public AuthManager(PasswordEncoder passwordEncoder, SecureRandom random, Clock clock) {
+        this.passwordEncoder = passwordEncoder;
+        this.random = random;
+        this.clock = clock;
+    }
+
+    public VerificationResult requestVerificationCode(String email, AuthRole role) {
+        String normalizedEmail = normalizeEmail(email);
+        validateEmail(normalizedEmail);
+        Instant now = clock.instant();
+        String key = codeKey(normalizedEmail, role);
+
+        VerificationCodeRecord existing = codeStore.get(key);
+        if (existing != null && Duration.between(existing.lastSentAt(), now).compareTo(RESEND_INTERVAL) < 0) {
+            throw new AuthException(AuthErrorCode.CODE_REQUEST_TOO_FREQUENT,
+                    "请在" + remainingSeconds(existing, now) + "秒后再试");
+        }
+
+        String code = generateCode();
+        Instant expireAt = now.plus(CODE_TTL);
+        VerificationCodeRecord record = new VerificationCodeRecord(code, expireAt, now, false, UUID.randomUUID().toString());
+        codeStore.put(key, record);
+
+        log.info("Generated verification code for email={}, role={}, code={}", normalizedEmail, role, code);
+        return new VerificationResult(record.requestId(), (int) CODE_TTL.getSeconds());
+    }
+
+    public AuthSession register(String email, String password, String verificationCode, AuthRole role) {
+        String normalizedEmail = normalizeEmail(email);
+        validateEmail(normalizedEmail);
+        validatePassword(password);
+
+        String codeKey = codeKey(normalizedEmail, role);
+        VerificationCodeRecord record = codeStore.get(codeKey);
+        if (record == null || record.consumed()) {
+            throw new AuthException(AuthErrorCode.CODE_NOT_FOUND);
+        }
+
+        Instant now = clock.instant();
+        if (now.isAfter(record.expireAt())) {
+            codeStore.remove(codeKey);
+            throw new AuthException(AuthErrorCode.CODE_EXPIRED);
+        }
+
+        if (!Objects.equals(record.code(), verificationCode)) {
+            throw new AuthException(AuthErrorCode.CODE_MISMATCH);
+        }
+
+        codeStore.put(codeKey, record.markConsumed());
+
+        String userKey = userKey(normalizedEmail, role);
+        UserAccount user = userStore.compute(userKey, (key, existing) -> {
+            if (existing != null) {
+                throw new AuthException(AuthErrorCode.USER_ALREADY_EXISTS);
+            }
+            String userId = UUID.randomUUID().toString();
+            String hashed = passwordEncoder.encode(password);
+            return new UserAccount(userId, normalizedEmail, role, hashed, now);
+        });
+
+        return createSession(user);
+    }
+
+    public AuthSession login(String email, String password, AuthRole role) {
+        String normalizedEmail = normalizeEmail(email);
+        validateEmail(normalizedEmail);
+        String userKey = userKey(normalizedEmail, role);
+        UserAccount user = userStore.get(userKey);
+        if (user == null || !passwordEncoder.matches(password, user.passwordHash())) {
+            throw new AuthException(AuthErrorCode.INVALID_CREDENTIALS);
+        }
+        return createSession(user);
+    }
+
+    private AuthSession createSession(UserAccount user) {
+        String accessToken = UUID.randomUUID().toString();
+        String refreshToken = UUID.randomUUID().toString();
+        return new AuthSession(user.userId(), user.email(), user.role(), accessToken, refreshToken);
+    }
+
+    private long remainingSeconds(VerificationCodeRecord record, Instant now) {
+        long elapsed = Duration.between(record.lastSentAt(), now).getSeconds();
+        long wait = RESEND_INTERVAL.getSeconds() - elapsed;
+        return Math.max(wait, 0);
+    }
+
+    private String normalizeEmail(String email) {
+        if (email == null) {
+            throw new AuthException(AuthErrorCode.INVALID_EMAIL);
+        }
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private void validateEmail(String email) {
+        if (!EMAIL_PATTERN.matcher(email).matches()) {
+            throw new AuthException(AuthErrorCode.INVALID_EMAIL);
+        }
+    }
+
+    private void validatePassword(String password) {
+        if (password == null || password.length() < 6) {
+            throw new AuthException(AuthErrorCode.PASSWORD_TOO_WEAK, "密码至少需要6位");
+        }
+    }
+
+    private String generateCode() {
+        int code = random.nextInt(900000) + 100000;
+        return Integer.toString(code);
+    }
+
+    private String codeKey(String email, AuthRole role) {
+        return email + "|" + role.name();
+    }
+
+    private String userKey(String email, AuthRole role) {
+        return email + "|" + role.name();
+    }
+
+    public record VerificationResult(String requestId, int expiresInSeconds) {}
+
+    public record AuthSession(String userId, String email, AuthRole role, String accessToken, String refreshToken) {}
+
+    private record VerificationCodeRecord(String code, Instant expireAt, Instant lastSentAt, boolean consumed, String requestId) {
+        VerificationCodeRecord markConsumed() {
+            return new VerificationCodeRecord(code, expireAt, lastSentAt, true, requestId);
+        }
+    }
+
+    private record UserAccount(String userId, String email, AuthRole role, String passwordHash, Instant createdAt) {}
+}

--- a/src/main/java/com/example/grpcdemo/auth/AuthRole.java
+++ b/src/main/java/com/example/grpcdemo/auth/AuthRole.java
@@ -1,0 +1,50 @@
+package com.example.grpcdemo.auth;
+
+import java.util.Locale;
+
+public enum AuthRole {
+    COMPANY("company", "ENTERPRISE"),
+    ENGINEER("engineer", "ENGINEER");
+
+    private final String alias;
+    private final String grpcValue;
+
+    AuthRole(String alias, String grpcValue) {
+        this.alias = alias;
+        this.grpcValue = grpcValue;
+    }
+
+    public String alias() {
+        return alias;
+    }
+
+    public String grpcValue() {
+        return grpcValue;
+    }
+
+    public static AuthRole fromAlias(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Role must not be null");
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        for (AuthRole role : values()) {
+            if (role.alias.equals(normalized)) {
+                return role;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported role alias: " + value);
+    }
+
+    public static AuthRole fromGrpcValue(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Role must not be null");
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        for (AuthRole role : values()) {
+            if (role.grpcValue.equals(normalized)) {
+                return role;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported role value: " + value);
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/AuthController.java
+++ b/src/main/java/com/example/grpcdemo/controller/AuthController.java
@@ -1,0 +1,68 @@
+package com.example.grpcdemo.controller;
+
+import com.example.grpcdemo.auth.AuthManager;
+import com.example.grpcdemo.auth.AuthRole;
+import com.example.grpcdemo.controller.dto.AuthResponseDto;
+import com.example.grpcdemo.controller.dto.LoginRequest;
+import com.example.grpcdemo.controller.dto.RegisterRequest;
+import com.example.grpcdemo.controller.dto.SendCodeRequest;
+import com.example.grpcdemo.controller.dto.VerificationCodeResponseDto;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class AuthController {
+
+    private final AuthManager authManager;
+
+    public AuthController(AuthManager authManager) {
+        this.authManager = authManager;
+    }
+
+    @PostMapping("/{segment}/auth/send-code")
+    public VerificationCodeResponseDto sendCode(@PathVariable("segment") String segment,
+                                                @Valid @RequestBody SendCodeRequest request) {
+        AuthRole role = resolveRole(segment);
+        AuthManager.VerificationResult result = authManager.requestVerificationCode(request.getEmail(), role);
+        return new VerificationCodeResponseDto(result.requestId(), result.expiresInSeconds());
+    }
+
+    @PostMapping("/{segment}/auth/register")
+    public AuthResponseDto register(@PathVariable("segment") String segment,
+                                    @Valid @RequestBody RegisterRequest request) {
+        AuthRole role = resolveRole(segment);
+        AuthManager.AuthSession session = authManager.register(request.getEmail(), request.getPassword(), request.getVerificationCode(), role);
+        return toDto(session);
+    }
+
+    @PostMapping("/{segment}/auth/login")
+    public AuthResponseDto login(@PathVariable("segment") String segment,
+                                 @Valid @RequestBody LoginRequest request) {
+        AuthRole role = resolveRole(segment);
+        AuthManager.AuthSession session = authManager.login(request.getEmail(), request.getPassword(), role);
+        return toDto(session);
+    }
+
+    private AuthRole resolveRole(String segment) {
+        return switch (segment.toLowerCase()) {
+            case "b", "company" -> AuthRole.COMPANY;
+            case "c", "engineer" -> AuthRole.ENGINEER;
+            default -> throw new IllegalArgumentException("未知的角色入口: " + segment);
+        };
+    }
+
+    private AuthResponseDto toDto(AuthManager.AuthSession session) {
+        return new AuthResponseDto(
+                session.userId(),
+                session.email(),
+                session.role().alias(),
+                session.accessToken(),
+                session.refreshToken()
+        );
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/grpcdemo/controller/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.example.grpcdemo.controller;
+
+import com.example.grpcdemo.auth.AuthErrorCode;
+import com.example.grpcdemo.auth.AuthException;
+import com.example.grpcdemo.controller.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException exception) {
+        FieldError fieldError = exception.getBindingResult().getFieldError();
+        String message = fieldError != null ? fieldError.getDefaultMessage() : "参数校验失败";
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("VALIDATION_ERROR", message));
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ErrorResponse> handleAuthException(AuthException exception) {
+        AuthErrorCode code = exception.getErrorCode();
+        return ResponseEntity.status(code.getHttpStatus())
+                .body(new ErrorResponse(code.name(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(AuthErrorCode.INVALID_ROLE.name(), exception.getMessage()));
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/AuthResponseDto.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/AuthResponseDto.java
@@ -1,0 +1,58 @@
+package com.example.grpcdemo.controller.dto;
+
+public class AuthResponseDto {
+
+    private String userId;
+    private String email;
+    private String role;
+    private String accessToken;
+    private String refreshToken;
+
+    public AuthResponseDto(String userId, String email, String role, String accessToken, String refreshToken) {
+        this.userId = userId;
+        this.email = email;
+        this.role = role;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/ErrorResponse.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/ErrorResponse.java
@@ -1,0 +1,28 @@
+package com.example.grpcdemo.controller.dto;
+
+public class ErrorResponse {
+
+    private String errorCode;
+    private String message;
+
+    public ErrorResponse(String errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/LoginRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/LoginRequest.java
@@ -1,0 +1,32 @@
+package com.example.grpcdemo.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class LoginRequest {
+
+    @NotBlank(message = "邮箱不能为空")
+    @Email(message = "邮箱格式不正确")
+    private String email;
+
+    @NotBlank(message = "密码不能为空")
+    @Size(min = 6, message = "密码至少需要6位")
+    private String password;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/RegisterRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/RegisterRequest.java
@@ -1,0 +1,43 @@
+package com.example.grpcdemo.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class RegisterRequest {
+
+    @NotBlank(message = "邮箱不能为空")
+    @Email(message = "邮箱格式不正确")
+    private String email;
+
+    @NotBlank(message = "密码不能为空")
+    @Size(min = 6, message = "密码至少需要6位")
+    private String password;
+
+    @NotBlank(message = "验证码不能为空")
+    private String verificationCode;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getVerificationCode() {
+        return verificationCode;
+    }
+
+    public void setVerificationCode(String verificationCode) {
+        this.verificationCode = verificationCode;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/SendCodeRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/SendCodeRequest.java
@@ -1,0 +1,19 @@
+package com.example.grpcdemo.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class SendCodeRequest {
+
+    @NotBlank(message = "邮箱不能为空")
+    @Email(message = "邮箱格式不正确")
+    private String email;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/VerificationCodeResponseDto.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/VerificationCodeResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.grpcdemo.controller.dto;
+
+public class VerificationCodeResponseDto {
+
+    private String requestId;
+    private int expiresInSeconds;
+
+    public VerificationCodeResponseDto(String requestId, int expiresInSeconds) {
+        this.requestId = requestId;
+        this.expiresInSeconds = expiresInSeconds;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public int getExpiresInSeconds() {
+        return expiresInSeconds;
+    }
+
+    public void setExpiresInSeconds(int expiresInSeconds) {
+        this.expiresInSeconds = expiresInSeconds;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
@@ -1,0 +1,98 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.auth.AuthErrorCode;
+import com.example.grpcdemo.auth.AuthException;
+import com.example.grpcdemo.auth.AuthManager;
+import com.example.grpcdemo.auth.AuthRole;
+import com.example.grpcdemo.proto.AuthServiceGrpc;
+import com.example.grpcdemo.proto.LoginRequest;
+import com.example.grpcdemo.proto.RegisterUserRequest;
+import com.example.grpcdemo.proto.UserResponse;
+import com.example.grpcdemo.proto.VerificationCodeRequest;
+import com.example.grpcdemo.proto.VerificationCodeResponse;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@GrpcService
+public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthServiceImpl.class);
+
+    private final AuthManager authManager;
+
+    public AuthServiceImpl(AuthManager authManager) {
+        this.authManager = authManager;
+    }
+
+    @Override
+    public void requestVerificationCode(VerificationCodeRequest request, StreamObserver<VerificationCodeResponse> responseObserver) {
+        try {
+            AuthRole role = AuthRole.fromGrpcValue(request.getRole());
+            AuthManager.VerificationResult result = authManager.requestVerificationCode(request.getEmail(), role);
+            VerificationCodeResponse response = VerificationCodeResponse.newBuilder()
+                    .setRequestId(result.requestId())
+                    .setExpiresInSeconds(result.expiresInSeconds())
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (IllegalArgumentException e) {
+            responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asRuntimeException());
+        } catch (AuthException e) {
+            handleAuthException(responseObserver, e);
+        } catch (Exception e) {
+            log.error("Unexpected error in requestVerificationCode", e);
+            responseObserver.onError(AuthErrorCode.INTERNAL_ERROR.getStatus().withDescription(e.getMessage()).asRuntimeException());
+        }
+    }
+
+    @Override
+    public void registerUser(RegisterUserRequest request, StreamObserver<UserResponse> responseObserver) {
+        try {
+            AuthRole role = AuthRole.fromGrpcValue(request.getRole());
+            AuthManager.AuthSession session = authManager.register(request.getEmail(), request.getPassword(), request.getVerificationCode(), role);
+            responseObserver.onNext(toUserResponse(session));
+            responseObserver.onCompleted();
+        } catch (IllegalArgumentException e) {
+            responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asRuntimeException());
+        } catch (AuthException e) {
+            handleAuthException(responseObserver, e);
+        } catch (Exception e) {
+            log.error("Unexpected error in registerUser", e);
+            responseObserver.onError(AuthErrorCode.INTERNAL_ERROR.getStatus().withDescription(e.getMessage()).asRuntimeException());
+        }
+    }
+
+    @Override
+    public void loginUser(LoginRequest request, StreamObserver<UserResponse> responseObserver) {
+        try {
+            AuthRole role = AuthRole.fromGrpcValue(request.getRole());
+            AuthManager.AuthSession session = authManager.login(request.getEmail(), request.getPassword(), role);
+            responseObserver.onNext(toUserResponse(session));
+            responseObserver.onCompleted();
+        } catch (IllegalArgumentException e) {
+            responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asRuntimeException());
+        } catch (AuthException e) {
+            handleAuthException(responseObserver, e);
+        } catch (Exception e) {
+            log.error("Unexpected error in loginUser", e);
+            responseObserver.onError(AuthErrorCode.INTERNAL_ERROR.getStatus().withDescription(e.getMessage()).asRuntimeException());
+        }
+    }
+
+    private UserResponse toUserResponse(AuthManager.AuthSession session) {
+        return UserResponse.newBuilder()
+                .setUserId(session.userId())
+                .setEmail(session.email())
+                .setRole(session.role().grpcValue())
+                .setAccessToken(session.accessToken())
+                .setRefreshToken(session.refreshToken())
+                .build();
+    }
+
+    private void handleAuthException(StreamObserver<?> responseObserver, AuthException exception) {
+        responseObserver.onError(exception.getErrorCode().getStatus().withDescription(exception.getMessage()).asRuntimeException());
+    }
+}

--- a/src/main/java/com/example/grpcdemo/service/NotificationServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/NotificationServiceImpl.java
@@ -1,0 +1,48 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.proto.NotificationServiceGrpc;
+import com.example.grpcdemo.proto.SendInvitationRequest;
+import com.example.grpcdemo.proto.SendInvitationResponse;
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@GrpcService
+public class NotificationServiceImpl extends NotificationServiceGrpc.NotificationServiceImplBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationServiceImpl.class);
+
+    private final JavaMailSender mailSender;
+
+    public NotificationServiceImpl(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    @Override
+    public void sendInvitation(SendInvitationRequest request, StreamObserver<SendInvitationResponse> responseObserver) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(request.getEmail());
+            message.setSubject(request.getSubject());
+            message.setText(request.getContent());
+            mailSender.send(message);
+            SendInvitationResponse response = SendInvitationResponse.newBuilder()
+                    .setSuccess(true)
+                    .setMessage("Invitation email sent.")
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            logger.error("Failed to send invitation email to {}", request.getEmail(), e);
+            SendInvitationResponse response = SendInvitationResponse.newBuilder()
+                    .setSuccess(false)
+                    .setMessage("Failed to send invitation email.")
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/src/main/java/com/example/grpcdemo/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/ReportServiceImpl.java
@@ -1,0 +1,49 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.proto.GenerateReportRequest;
+import com.example.grpcdemo.proto.GetReportRequest;
+import com.example.grpcdemo.proto.ReportResponse;
+import com.example.grpcdemo.proto.ReportServiceGrpc;
+import io.grpc.Status;
+
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@GrpcService
+public class ReportServiceImpl extends ReportServiceGrpc.ReportServiceImplBase {
+
+    private final Map<String, ReportResponse> reportStore = new ConcurrentHashMap<>();
+
+    @Override
+    public void generateReport(GenerateReportRequest request,
+                               StreamObserver<ReportResponse> responseObserver) {
+        String reportId = UUID.randomUUID().toString();
+        ReportResponse response = ReportResponse.newBuilder()
+                .setReportId(reportId)
+                .setInterviewId(request.getInterviewId())
+                .setContent("Report placeholder")
+                .setScore(0)
+                .setEvaluatorComment("")
+                .setCreatedAt(System.currentTimeMillis())
+                .build();
+        reportStore.put(reportId, response);
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getReport(GetReportRequest request,
+                          StreamObserver<ReportResponse> responseObserver) {
+        ReportResponse response = reportStore.get(request.getReportId());
+        if (response == null) {
+            responseObserver.onError(Status.NOT_FOUND.withDescription("Report not found").asRuntimeException());
+            return;
+        }
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+}

--- a/src/main/proto/auth.proto
+++ b/src/main/proto/auth.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.example.grpcdemo.proto";
+option java_outer_classname = "AuthProto";
+
+package auth;
+
+service AuthService {
+  rpc RequestVerificationCode (VerificationCodeRequest) returns (VerificationCodeResponse);
+  rpc RegisterUser (RegisterUserRequest) returns (UserResponse);
+  rpc LoginUser (LoginRequest) returns (UserResponse);
+}
+
+message VerificationCodeRequest {
+  string email = 1;
+  string role = 2;
+}
+
+message VerificationCodeResponse {
+  string requestId = 1;
+  int32 expiresInSeconds = 2;
+}
+
+message RegisterUserRequest {
+  string email = 1;
+  string password = 2;
+  string role = 3;
+  string verificationCode = 4;
+}
+
+message LoginRequest {
+  string email = 1;
+  string password = 2;
+  string role = 3;
+}
+
+message UserResponse {
+  string userId = 1;
+  string email = 2;
+  string role = 3;
+  string accessToken = 4;
+  string refreshToken = 5;
+}

--- a/src/main/proto/notification.proto
+++ b/src/main/proto/notification.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.example.grpcdemo.proto";
+option java_outer_classname = "NotificationProto";
+
+package notification;
+
+service NotificationService {
+  rpc SendInvitation (SendInvitationRequest) returns (SendInvitationResponse);
+}
+
+message SendInvitationRequest {
+  string email = 1;
+  string subject = 2;
+  string content = 3;
+}
+
+message SendInvitationResponse {
+  bool success = 1;
+  string message = 2;
+}

--- a/src/main/proto/report.proto
+++ b/src/main/proto/report.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.example.grpcdemo.proto";
+option java_outer_classname = "ReportProto";
+
+package report;
+
+service ReportService {
+  rpc GenerateReport(GenerateReportRequest) returns (ReportResponse);
+  rpc GetReport(GetReportRequest) returns (ReportResponse);
+}
+
+message GenerateReportRequest {
+  string interviewId = 1;
+}
+
+message GetReportRequest {
+  string reportId = 1;
+}
+
+message ReportResponse {
+  string reportId = 1;
+  string interviewId = 2;
+  string content = 3;
+  float score = 4;
+  string evaluatorComment = 5;
+  int64 createdAt = 6;
+}


### PR DESCRIPTION
## Summary
- extend auth.proto and service implementation to support verification codes, secure password hashing, and proper error statuses
- add AuthManager domain component with cooldown logic, token issuance, and role handling for company and engineer flows
- expose REST gateway endpoints for B/C portals with validation and global error handling, updating API docs and dependencies accordingly

## Testing
- `./mvnw -q compile` *(fails: wget unable to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68c129af800c83319d29eca1d13d52d9