### PR TITLE
Fix authentication and reporting services

### DIFF
--- a/src/main/java/com/example/grpcdemo/service/InterviewServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/InterviewServiceImpl.java
@@ -121,53 +121,6 @@ public class InterviewServiceImpl extends InterviewServiceGrpc.InterviewServiceI
     }
 
     @Override
-    public void getInterview(InterviewRequest request, StreamObserver<InterviewResponse> responseObserver) {
-        InterviewResponse response = repository.findById(request.getInterviewId())
-                .map(this::toResponse)
-                .orElse(InterviewResponse.newBuilder()
-                        .setInterviewId(request.getInterviewId())
-                        .setStatus("NOT_FOUND")
-                        .build());
-        responseObserver.onNext(response);
-        responseObserver.onCompleted();
-    }
-
-    @Override
-    public void completeInterview(InterviewRequest request, StreamObserver<InterviewResponse> responseObserver) {
-        Interview interview = repository.findById(request.getInterviewId()).orElse(null);
-        if (interview == null) {
-            responseObserver.onNext(InterviewResponse.newBuilder()
-                    .setInterviewId(request.getInterviewId())
-                    .setStatus("NOT_FOUND")
-                    .build());
-            responseObserver.onCompleted();
-            return;
-        }
-        interview.setStatus("COMPLETED");
-        Interview updated = repository.save(interview);
-        responseObserver.onNext(toResponse(updated));
-        responseObserver.onCompleted();
-    }
-
-    @Override
-    public void deleteInterview(InterviewRequest request, StreamObserver<InterviewResponse> responseObserver) {
-        InterviewResponse response = repository.findById(request.getInterviewId())
-                .map(interview -> {
-                    repository.delete(interview);
-                    return InterviewResponse.newBuilder()
-                            .setInterviewId(request.getInterviewId())
-                            .setStatus("DELETED")
-                            .build();
-                })
-                .orElse(InterviewResponse.newBuilder()
-                        .setInterviewId(request.getInterviewId())
-                        .setStatus("NOT_FOUND")
-                        .build());
-        responseObserver.onNext(response);
-        responseObserver.onCompleted();
-    }
-
-    @Override
     public void getInterviewsByCandidate(GetInterviewsByCandidateRequest request, StreamObserver<InterviewsResponse> responseObserver) {
         List<InterviewResponse> list = repository.findByCandidateId(request.getCandidateId()).stream()
                 .map(this::toResponse)
@@ -195,4 +148,3 @@ public class InterviewServiceImpl extends InterviewServiceGrpc.InterviewServiceI
                 .build();
     }
 }
-

--- a/src/main/java/com/example/grpcdemo/service/NotificationServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/NotificationServiceImpl.java
@@ -3,33 +3,36 @@ package com.example.grpcdemo.service;
 import com.example.grpcdemo.proto.NotificationServiceGrpc;
 import com.example.grpcdemo.proto.SendInvitationRequest;
 import com.example.grpcdemo.proto.SendInvitationResponse;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 
+/**
+ * gRPC service responsible for sending email invitations.
+ */
 @GrpcService
 public class NotificationServiceImpl extends NotificationServiceGrpc.NotificationServiceImplBase {
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationServiceImpl.class);
-
 
     private final JavaMailSender mailSender;
 
     public NotificationServiceImpl(JavaMailSender mailSender) {
         this.mailSender = mailSender;
     }
-  
+
     @Override
     public void sendInvitation(SendInvitationRequest request, StreamObserver<SendInvitationResponse> responseObserver) {
         try {
-
             SimpleMailMessage message = new SimpleMailMessage();
             message.setTo(request.getEmail());
             message.setSubject(request.getSubject());
-            message.setText(request.getContent())
+            message.setText(request.getContent());
             mailSender.send(message);
 
             logger.info("Sent invitation email to {} with subject '{}'", request.getEmail(), request.getSubject());
@@ -47,11 +50,10 @@ public class NotificationServiceImpl extends NotificationServiceGrpc.Notificatio
                 detailedMessage = baseMessage + ". Cause: " + e.getMessage();
             }
 
-            logger.error("{}", detailedMessage, e);
-            responseObserver.onError(
-                    Status.INTERNAL
-                            .withDescription(detailedMessage)
-                            .asRuntimeException());
+            logger.error(detailedMessage, e);
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription(detailedMessage)
+                    .asRuntimeException());
         }
     }
 }

--- a/src/main/java/com/example/grpcdemo/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/ReportServiceImpl.java
@@ -1,57 +1,77 @@
 package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.entity.ReportEntity;
 import com.example.grpcdemo.proto.GenerateReportRequest;
 import com.example.grpcdemo.proto.GetReportRequest;
 import com.example.grpcdemo.proto.ReportResponse;
 import com.example.grpcdemo.proto.ReportServiceGrpc;
+import com.example.grpcdemo.repository.ReportRepository;
 import io.grpc.Status;
-
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-
+/**
+ * gRPC service that delegates report generation to the {@link ReportGenerator}
+ * and persists generated reports using {@link ReportRepository}.
+ */
 @GrpcService
 public class ReportServiceImpl extends ReportServiceGrpc.ReportServiceImplBase {
 
-    private final Map<String, ReportResponse> reportStore = new ConcurrentHashMap<>();
-  
+    private static final Logger log = LoggerFactory.getLogger(ReportServiceImpl.class);
+
+    private final ReportRepository reportRepository;
+    private final ReportGenerator reportGenerator;
+
+    public ReportServiceImpl(ReportRepository reportRepository, ReportGenerator reportGenerator) {
+        this.reportRepository = reportRepository;
+        this.reportGenerator = reportGenerator;
+    }
+
     @Override
     public void generateReport(GenerateReportRequest request,
                                StreamObserver<ReportResponse> responseObserver) {
-        String reportId = UUID.randomUUID().toString();
-        ReportResponse response = ReportResponse.newBuilder()
-                .setReportId(reportId)
-                .setInterviewId(request.getInterviewId())
-                .setContent("Report placeholder")
-                .setScore(0)
-                .setEvaluatorComment("")
-                .setCreatedAt(System.currentTimeMillis())
-                .build();
-        reportStore.put(reportId, response);
-        responseObserver.onNext(response);
-        responseObserver.onCompleted();
-
-    @Override
-    public void getReport(GetReportRequest request,
-                          StreamObserver<ReportResponse> responseObserver) {
-
-        ReportResponse response = reportStore.get(request.getReportId());
-        if (response == null) {
-            responseObserver.onError(Status.NOT_FOUND.withDescription("Report not found").asRuntimeException());
+        String interviewId = request.getInterviewId();
+        if (interviewId.isBlank()) {
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                    .withDescription("Interview id must not be empty")
+                    .asRuntimeException());
             return;
         }
-        responseObserver.onNext(response);
-        responseObserver.onCompleted();
+        try {
+            ReportEntity entity = reportGenerator.generateAndStore(interviewId);
+            responseObserver.onNext(toResponse(entity));
+            responseObserver.onCompleted();
+        } catch (InterviewNotFoundException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .asRuntimeException());
+        } catch (Exception e) {
+            log.error("Failed to generate report for interview {}", interviewId, e);
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription("Failed to generate report")
+                    .asRuntimeException());
+        }
+    }
 
-        reportRepository.findById(request.getReportId())
+    @Override
+    public void getReport(GetReportRequest request, StreamObserver<ReportResponse> responseObserver) {
+        String reportId = request.getReportId();
+        if (reportId.isBlank()) {
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                    .withDescription("Report id must not be empty")
+                    .asRuntimeException());
+            return;
+        }
+        reportRepository.findById(reportId)
                 .map(this::toResponse)
                 .ifPresentOrElse(response -> {
                     responseObserver.onNext(response);
                     responseObserver.onCompleted();
-                }, () -> responseObserver.onError(
-                        Status.NOT_FOUND.withDescription("Report not found").asRuntimeException()));
+                }, () -> responseObserver.onError(Status.NOT_FOUND
+                        .withDescription("Report not found")
+                        .asRuntimeException()));
     }
 
     private ReportResponse toResponse(ReportEntity entity) {

--- a/src/main/proto/auth.proto
+++ b/src/main/proto/auth.proto
@@ -6,54 +6,35 @@ option java_outer_classname = "AuthProto";
 
 package auth;
 
-// --- 统一的用户类型（企业/工程师） ---
-enum UserType {
-  USER_TYPE_UNSPECIFIED = 0;
-  ENTERPRISE = 1; // 企业端(B端)
-  ENGINEER   = 2; // 工程师端(C端)
-}
-
-// --- 认证服务 ---
+// Authentication service providing registration and login flows.
 service AuthService {
-  // 注册（邮箱 + 验证码）
-  rpc RegisterUser (RegisterUserRequest) returns (AuthResponse);
+  // Register a new user account.
+  rpc RegisterUser (RegisterUserRequest) returns (UserResponse);
 
-  // 登录（邮箱 + 验证码）
-  rpc Login (LoginRequest) returns (AuthResponse);
-
-  // 发送验证码（可选）
-  rpc SendVerificationCode (SendCodeRequest) returns (SendCodeResponse);
+  // Login using username and password credentials.
+  rpc LoginUser (LoginRequest) returns (UserResponse);
 }
 
-// --- 请求/响应消息 ---
+// Request payload used to register a new user.
 message RegisterUserRequest {
-  string  email              = 1;
-  string  verification_code  = 2;
-  UserType user_type         = 3; // ENTERPRISE/ENGINEER
-  string  password           = 4; // 如无需密码，可忽略
+  string username = 1;
+  string password = 2;
+  string role = 3;
+  string email = 4;
 }
 
+// Request payload used to login an existing user.
 message LoginRequest {
-  string  email              = 1;
-  string  verification_code  = 2;
-  UserType user_type         = 3;
+  string username = 1;
+  string password = 2;
 }
 
-message SendCodeRequest {
-  string  email              = 1;
-  UserType user_type         = 2;
-}
-
-message SendCodeResponse {
-  bool   success   = 1;
-  string error     = 2; // 失败原因(可选)
-}
-
-message AuthResponse {
-  bool   success       = 1;
-  string user_id       = 2;
-  string access_token  = 3;
-  int64  expires_at    = 4; // epoch millis
-  string refresh_token = 5; // 可选
-  string error         = 6; // 失败原因(可选)
+// Response returned after successful authentication.
+message UserResponse {
+  string user_id = 1;
+  string username = 2;
+  string role = 3;
+  string access_token = 4;
+  string refresh_token = 5;
+  string email = 6;
 }


### PR DESCRIPTION
## Summary
- align the gRPC auth service and protobuf definitions with the repository-backed implementation, issuing JWT tokens on register/login
- tidy the interview service implementation to remove duplicate RPC overrides
- rebuild the report and notification services to use the report generator/repository and proper error handling

## Testing
- mvn -q -DskipTests compile *(fails: unable to download spring-boot-starter-parent because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d49682996c83319fa815e7733e64b3