### PR TITLE
Implement password reset flow with verification

### DIFF
--- a/src/main/java/com/example/grpcdemo/auth/AuthErrorCode.java
+++ b/src/main/java/com/example/grpcdemo/auth/AuthErrorCode.java
@@ -11,6 +11,7 @@ public enum AuthErrorCode {
     CODE_EXPIRED(Status.DEADLINE_EXCEEDED, HttpStatus.BAD_REQUEST, "验证码已过期"),
     CODE_MISMATCH(Status.PERMISSION_DENIED, HttpStatus.BAD_REQUEST, "验证码不匹配"),
     USER_ALREADY_EXISTS(Status.ALREADY_EXISTS, HttpStatus.CONFLICT, "用户已存在"),
+    USER_NOT_FOUND(Status.NOT_FOUND, HttpStatus.BAD_REQUEST, "用户不存在"),
     PASSWORD_TOO_WEAK(Status.INVALID_ARGUMENT, HttpStatus.BAD_REQUEST, "密码强度不足"),
     INVALID_CREDENTIALS(Status.UNAUTHENTICATED, HttpStatus.UNAUTHORIZED, "邮箱或密码错误"),
     INTERNAL_ERROR(Status.INTERNAL, HttpStatus.INTERNAL_SERVER_ERROR, "系统内部错误");

--- a/src/main/java/com/example/grpcdemo/controller/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/ResetPasswordRequest.java
@@ -1,0 +1,44 @@
+package com.example.grpcdemo.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class ResetPasswordRequest {
+
+    @NotBlank(message = "邮箱不能为空")
+    @Email(message = "邮箱格式不正确")
+    private String email;
+
+    @NotBlank(message = "验证码不能为空")
+    @Size(min = 6, max = 6, message = "验证码必须为6位数字")
+    private String verificationCode;
+
+    @NotBlank(message = "新密码不能为空")
+    @Size(min = 6, message = "密码至少需要6位")
+    private String newPassword;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getVerificationCode() {
+        return verificationCode;
+    }
+
+    public void setVerificationCode(String verificationCode) {
+        this.verificationCode = verificationCode;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/SuccessResponse.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/SuccessResponse.java
@@ -1,0 +1,14 @@
+package com.example.grpcdemo.controller.dto;
+
+public class SuccessResponse {
+
+    private final String message;
+
+    public SuccessResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/entity/UserAccountEntity.java
+++ b/src/main/java/com/example/grpcdemo/entity/UserAccountEntity.java
@@ -4,18 +4,19 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 /**
  * JPA entity representing a registered user account.
  */
 @Entity
-@Table(name = "user_accounts")
+@Table(name = "user_accounts", uniqueConstraints = @UniqueConstraint(columnNames = {"username", "role"}))
 public class UserAccountEntity {
 
     @Id
     private String userId;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String username;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/grpcdemo/repository/UserAccountRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/UserAccountRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
  */
 public interface UserAccountRepository extends JpaRepository<UserAccountEntity, String> {
 
-    Optional<UserAccountEntity> findByUsername(String username);
+    Optional<UserAccountEntity> findByUsernameAndRole(String username, String role);
 }

--- a/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
@@ -45,7 +45,7 @@ public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
             return;
         }
 
-        Optional<UserAccountEntity> existing = userRepository.findByUsername(username);
+        Optional<UserAccountEntity> existing = userRepository.findByUsernameAndRole(username, role);
         if (existing.isPresent()) {
             responseObserver.onError(Status.ALREADY_EXISTS
                     .withDescription("User already exists")
@@ -75,7 +75,7 @@ public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
             return;
         }
 
-        Optional<UserAccountEntity> existing = userRepository.findByUsername(username);
+        Optional<UserAccountEntity> existing = userRepository.findByUsernameAndRole(username, request.getRole().trim());
         if (existing.isEmpty() || !passwordEncoder.matches(password, existing.get().getPasswordHash())) {
             responseObserver.onError(Status.UNAUTHENTICATED
                     .withDescription("Invalid username or password")


### PR DESCRIPTION
## Summary
- persist user accounts through the existing repository inside the auth manager and reuse them for login/session issuance
- add dedicated endpoints and DTOs for password reset code delivery and password update once the code is verified
- enforce username and role uniqueness in the database and update the gRPC auth service to use the combined lookup

## Testing
- mvn -q test *(fails: unable to download parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d62746c1ac833185f804dfafa4c95a