### PR TITLE
Add verification purpose handling for password reset codes

### DIFF
--- a/src/main/java/com/example/grpcdemo/auth/AuthErrorCode.java
+++ b/src/main/java/com/example/grpcdemo/auth/AuthErrorCode.java
@@ -11,6 +11,7 @@ public enum AuthErrorCode {
     CODE_EXPIRED(Status.DEADLINE_EXCEEDED, HttpStatus.BAD_REQUEST, "验证码已过期"),
     CODE_MISMATCH(Status.PERMISSION_DENIED, HttpStatus.BAD_REQUEST, "验证码不匹配"),
     USER_ALREADY_EXISTS(Status.ALREADY_EXISTS, HttpStatus.CONFLICT, "用户已存在"),
+    USER_NOT_FOUND(Status.NOT_FOUND, HttpStatus.NOT_FOUND, "用户不存在"),
     PASSWORD_TOO_WEAK(Status.INVALID_ARGUMENT, HttpStatus.BAD_REQUEST, "密码强度不足"),
     INVALID_CREDENTIALS(Status.UNAUTHENTICATED, HttpStatus.UNAUTHORIZED, "邮箱或密码错误"),
     INTERNAL_ERROR(Status.INTERNAL, HttpStatus.INTERNAL_SERVER_ERROR, "系统内部错误");

--- a/src/main/java/com/example/grpcdemo/auth/VerificationPurpose.java
+++ b/src/main/java/com/example/grpcdemo/auth/VerificationPurpose.java
@@ -1,0 +1,16 @@
+package com.example.grpcdemo.auth;
+
+/**
+ * Represents the purpose of a verification code request.
+ */
+public enum VerificationPurpose {
+    /**
+     * Used when a user is registering a brand-new account.
+     */
+    REGISTER,
+
+    /**
+     * Used when a user is resetting a forgotten password.
+     */
+    RESET_PASSWORD
+}

--- a/src/main/java/com/example/grpcdemo/controller/AuthController.java
+++ b/src/main/java/com/example/grpcdemo/controller/AuthController.java
@@ -28,7 +28,7 @@ public class AuthController {
     public VerificationCodeResponseDto sendCode(@PathVariable("segment") String segment,
                                                 @Valid @RequestBody SendCodeRequest request) {
         AuthRole role = resolveRole(segment);
-        AuthManager.VerificationResult result = authManager.requestVerificationCode(request.getEmail(), role);
+        AuthManager.VerificationResult result = authManager.requestVerificationCode(request.getEmail(), role, request.getPurpose());
         return new VerificationCodeResponseDto(result.requestId(), result.expiresInSeconds());
     }
 

--- a/src/main/java/com/example/grpcdemo/controller/dto/SendCodeRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/SendCodeRequest.java
@@ -1,7 +1,9 @@
 package com.example.grpcdemo.controller.dto;
 
+import com.example.grpcdemo.auth.VerificationPurpose;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public class SendCodeRequest {
 
@@ -9,11 +11,22 @@ public class SendCodeRequest {
     @Email(message = "邮箱格式不正确")
     private String email;
 
+    @NotNull(message = "验证码用途不能为空")
+    private VerificationPurpose purpose = VerificationPurpose.REGISTER;
+
     public String getEmail() {
         return email;
     }
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public VerificationPurpose getPurpose() {
+        return purpose;
+    }
+
+    public void setPurpose(VerificationPurpose purpose) {
+        this.purpose = purpose != null ? purpose : VerificationPurpose.REGISTER;
     }
 }


### PR DESCRIPTION
## Summary
- add a verification purpose field to code requests so the backend knows whether it is for registration or password reset
- block code delivery when the purpose is registration and the user already exists or when it is password reset and the user is not registered
- expose a new user-not-found error code so the UI can surface the proper feedback

## Testing
- `./mvnw test` *(fails: unable to download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6275065b883318a92e245b8364d10