### PR TITLE
Fix authentication flows and proto login request

### DIFF
--- a/src/main/java/com/example/grpcdemo/controller/AuthController.java
+++ b/src/main/java/com/example/grpcdemo/controller/AuthController.java
@@ -30,8 +30,11 @@ public class AuthController {
     public VerificationCodeResponseDto sendResetCode(@PathVariable("segment") String segment,
                                                      @Valid @RequestBody SendCodeRequest request) {
         AuthRole role = resolveRole(segment);
-        AuthManager.VerificationResult result = authManager.requestPasswordResetCode(request.getEmail(), role);
-        AuthManager.VerificationResult result = authManager.requestVerificationCode(request.getEmail(), role, request.getPurpose());
+        AuthManager.VerificationResult result = authManager.requestVerificationCode(
+                request.getEmail(),
+                role,
+                request.getPurpose()
+        );
         return new VerificationCodeResponseDto(result.requestId(), result.expiresInSeconds());
     }
 

--- a/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
@@ -67,15 +67,16 @@ public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
     public void loginUser(LoginRequest request, StreamObserver<UserResponse> responseObserver) {
         String username = request.getUsername().trim();
         String password = request.getPassword();
+        String role = request.getRole().trim();
 
-        if (username.isEmpty() || password.isEmpty()) {
+        if (username.isEmpty() || password.isEmpty() || role.isEmpty()) {
             responseObserver.onError(Status.INVALID_ARGUMENT
-                    .withDescription("Username and password are required")
+                    .withDescription("Username, password and role are required")
                     .asRuntimeException());
             return;
         }
 
-        Optional<UserAccountEntity> existing = userRepository.findByUsernameAndRole(username, request.getRole().trim());
+        Optional<UserAccountEntity> existing = userRepository.findByUsernameAndRole(username, role);
         if (existing.isEmpty() || !passwordEncoder.matches(password, existing.get().getPasswordHash())) {
             responseObserver.onError(Status.UNAUTHENTICATED
                     .withDescription("Invalid username or password")
@@ -94,6 +95,7 @@ public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
                 .setUserId(entity.getUserId())
                 .setUsername(entity.getUsername())
                 .setRole(entity.getRole())
+                .setEmail(entity.getUsername())
                 .setAccessToken(accessToken)
                 .setRefreshToken(refreshToken)
                 .build();

--- a/src/main/proto/auth.proto
+++ b/src/main/proto/auth.proto
@@ -27,6 +27,7 @@ message RegisterUserRequest {
 message LoginRequest {
   string username = 1;
   string password = 2;
+  string role = 3;
 }
 
 // Response returned after successful authentication.


### PR DESCRIPTION
## Summary
- expose a generic verification-code entry point in `AuthManager` while preventing duplicate registrations and removing dead fields
- update the REST auth controller to call the unified verification-code logic
- require a role when logging in over gRPC, include the role in the proto, and populate the email in responses

## Testing
- `mvn -q -DskipTests clean generate-sources compile` *(fails: unable to download parent POM because Maven Central returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d62cf09ef08331acac9196496cc6f4