### PR TITLE
Fix Supabase schema to avoid auth permission errors

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,127 @@
+-- EvolutionAI backend database schema
+--
+-- This script targets PostgreSQL (Supabase) and captures the tables used by the
+-- Spring Data JPA entities in this repository. Run inside the target database
+-- to create the required structures.
+
+BEGIN;
+
+-- Optional extensions for nicer data types / functions. They are safe to run on
+-- Supabase as they are available by default.
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS citext;
+
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.user_accounts (
+    user_id         uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    username        citext      NOT NULL,
+    password_hash   text        NOT NULL,
+    role            varchar(32) NOT NULL,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    updated_at      timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT user_accounts_username_role_key UNIQUE (username, role),
+    CONSTRAINT user_accounts_role_check CHECK (role IN ('company', 'engineer'))
+);
+
+CREATE INDEX IF NOT EXISTS user_accounts_username_idx
+    ON public.user_accounts (username);
+
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_user_accounts_updated_at
+    ON public.user_accounts;
+CREATE TRIGGER set_user_accounts_updated_at
+    BEFORE UPDATE ON public.user_accounts
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_updated_at();
+
+-- ============================================================================
+--  Core recruiting domain tables
+-- ============================================================================
+CREATE SCHEMA IF NOT EXISTS app_public;
+
+CREATE TABLE IF NOT EXISTS app_public.jobs (
+    id          uuid PRIMARY KEY,
+    job_title   varchar(255) NOT NULL,
+    description text,
+    status      varchar(50)  NOT NULL,
+    created_at  timestamptz  NOT NULL DEFAULT now(),
+    updated_at  timestamptz  NOT NULL DEFAULT now()
+);
+
+DROP TRIGGER IF EXISTS set_jobs_updated_at
+    ON app_public.jobs;
+CREATE TRIGGER set_jobs_updated_at
+    BEFORE UPDATE ON app_public.jobs
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE IF NOT EXISTS app_public.candidates (
+    id         uuid PRIMARY KEY,
+    name       varchar(255) NOT NULL,
+    email      varchar(255),
+    phone      varchar(50),
+    status     varchar(50)  NOT NULL DEFAULT 'CREATED',
+    created_at timestamptz  NOT NULL DEFAULT now(),
+    updated_at timestamptz  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS candidates_email_idx
+    ON app_public.candidates (email);
+
+DROP TRIGGER IF EXISTS set_candidates_updated_at
+    ON app_public.candidates;
+CREATE TRIGGER set_candidates_updated_at
+    BEFORE UPDATE ON app_public.candidates
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE IF NOT EXISTS app_public.interviews (
+    id             uuid PRIMARY KEY,
+    candidate_id   uuid REFERENCES app_public.candidates (id) ON DELETE SET NULL,
+    job_id         uuid REFERENCES app_public.jobs (id) ON DELETE SET NULL,
+    scheduled_time timestamptz,
+    status         varchar(50) NOT NULL,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS interviews_candidate_idx
+    ON app_public.interviews (candidate_id);
+CREATE INDEX IF NOT EXISTS interviews_job_idx
+    ON app_public.interviews (job_id);
+
+DROP TRIGGER IF EXISTS set_interviews_updated_at
+    ON app_public.interviews;
+CREATE TRIGGER set_interviews_updated_at
+    BEFORE UPDATE ON app_public.interviews
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE IF NOT EXISTS app_public.reports (
+    report_id          uuid PRIMARY KEY,
+    interview_id       uuid NOT NULL REFERENCES app_public.interviews (id) ON DELETE CASCADE,
+    content            text,
+    score              real,
+    evaluator_comment  text,
+    created_at         timestamptz NOT NULL DEFAULT now(),
+    updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS reports_interview_idx
+    ON app_public.reports (interview_id);
+
+DROP TRIGGER IF EXISTS set_reports_updated_at
+    ON app_public.reports;
+CREATE TRIGGER set_reports_updated_at
+    BEFORE UPDATE ON app_public.reports
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_updated_at();
+
+COMMIT;

--- a/docs/supabase-migrations.md
+++ b/docs/supabase-migrations.md
@@ -1,0 +1,48 @@
+# Supabase 数据库设置
+
+本文档介绍如何让 Supabase（PostgreSQL）项目与本仓库中的实体保持一致，并使用 Supabase CLI 管理未来的架构变更。
+
+## 数据表概览
+
+该应用使用 Spring Data JPA，包含以下持久化聚合：
+
+| Java 类型 | 表 | 作用 |
+|-----------|----|------|
+| `UserAccountEntity` | `public.user_accounts` | 存储注册的登录账号。代码需要 `username`、`password_hash` 和 `role` 字段，并在 `(username, role)` 上设置唯一约束。 |
+| `Job` | `app_public.jobs` | 表示通过 gRPC job 服务对外暴露的职位信息。 |
+| `Candidate` | `app_public.candidates` | 表示导入系统的候选人。 |
+| `Interview` | `app_public.interviews` | 将候选人与职位关联，并保存面试的排期状态。 |
+| `ReportEntity` | `app_public.reports` | 保存完成面试后的 AI 评估结果。 |
+
+字段类型、长度限制以及约束定义都在 [`db/schema.sql`](../db/schema.sql) 中给出。
+
+> **登录模块如何落地？** 上表中的 `public.user_accounts` 承担了注册与登录所需的全部字段（用户名、哈希后的密码、角色及审计时间戳），其结构与 Spring Security/JPA 中的 `UserAccountEntity` 一一对应。脚本还包含触发器 `set_user_accounts_updated_at` 用于维护更新时间戳；执行 `db/schema.sql` 后就具备了后端代码完成注册、鉴权的最低要求，不需要额外手动建表。
+
+## 应用数据库结构
+
+1. 认证 Supabase CLI 并关联到你的项目：
+   ```bash
+   supabase login
+   supabase link --project-ref <your-project-ref>
+   ```
+2. 将数据库结构推送到远程数据库：
+   ```bash
+   supabase db push --file db/schema.sql
+   ```
+   该命令会在项目的主数据库上执行 `db/schema.sql` 中的 SQL，并在 CLI 的历史记录中保留部署信息。
+
+你也可以打开 Supabase SQL 编辑器，粘贴 `db/schema.sql` 的内容来手动创建这些数据表。
+
+> **注意权限问题**：Supabase 的 `auth` schema 由平台内部管理，普通数据库角色（如 `postgres`、`service_role`）默认没有在该 schema 下创建表或函数的权限。如果执行旧版本的脚本出现 `permission denied for schema auth`，请改用当前版本的 `db/schema.sql`，它会在 `public` 与 `app_public` schema 中创建业务所需的对象。
+
+## 使用迁移跟踪后续变更
+
+Supabase CLI 支持可纳入 Git 版本管理的迁移脚本：
+
+```bash
+supabase migration new add_status_column_to_jobs
+```
+
+该命令会在 `supabase/migrations` 目录下创建一个带时间戳的 SQL 文件。将 DDL 语句（例如 `ALTER TABLE app_public.jobs ADD COLUMN ...`）写入该文件，提交后再通过 `supabase db push` 推送到数据库。
+
+将架构变更纳入版本控制，可以确保云端数据库与 Java 实体在项目演进过程中保持同步。


### PR DESCRIPTION
## Summary
- move the custom user accounts table and triggers into the public schema so Supabase roles can create them without auth schema permissions
- note the schema change, explain the auth schema permission limitation, and clarify that the public.user_accounts table covers all login requirements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d67ebe47408331a281259d4e1ee071