### PR TITLE
Fix AuthServiceImpl tests to include role in login requests

### DIFF
--- a/src/test/java/com/example/grpcdemo/service/AuthServiceImplTest.java
+++ b/src/test/java/com/example/grpcdemo/service/AuthServiceImplTest.java
@@ -64,6 +64,7 @@ class AuthServiceImplTest {
         LoginRequest loginRequest = LoginRequest.newBuilder()
                 .setUsername("valid-user")
                 .setPassword("strong-password")
+                .setRole("ADMIN")
                 .build();
 
         authService.loginUser(loginRequest, loginObserver);
@@ -95,6 +96,7 @@ class AuthServiceImplTest {
         LoginRequest loginRequest = LoginRequest.newBuilder()
                 .setUsername("invalid-user")
                 .setPassword("wrong-password")
+                .setRole("USER")
                 .build();
 
         authService.loginUser(loginRequest, loginObserver);


### PR DESCRIPTION
## Summary
- ensure AuthServiceImpl tests include role when logging in so requests are valid

## Testing
- `./mvnw test` *(fails: wget could not download Maven distribution in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d73fae64a083318c5650263a640d54