### PR TITLE
Add verification email support for password reset and registration

### DIFF
--- a/src/main/java/com/example/grpcdemo/auth/MailVerificationCodeSender.java
+++ b/src/main/java/com/example/grpcdemo/auth/MailVerificationCodeSender.java
@@ -1,0 +1,60 @@
+package com.example.grpcdemo.auth;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Sends verification codes via email using {@link JavaMailSender}.
+ */
+@Component
+public class MailVerificationCodeSender implements VerificationCodeSender {
+
+    private static final Logger log = LoggerFactory.getLogger(MailVerificationCodeSender.class);
+
+    private final JavaMailSender mailSender;
+
+    public MailVerificationCodeSender(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    @Override
+    public void sendVerificationCode(String email,
+                                      String code,
+                                      AuthRole role,
+                                      VerificationPurpose purpose,
+                                      Duration ttl) {
+        String subject = buildSubject(purpose);
+        String body = buildBody(code, ttl);
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject(subject);
+        message.setText(body);
+
+        try {
+            mailSender.send(message);
+            log.info("Sent {} verification code to email={}, role={}", purpose, email, role);
+        } catch (MailException ex) {
+            log.error("Failed to send verification code email to {}", email, ex);
+            throw new AuthException(AuthErrorCode.INTERNAL_ERROR, "验证码发送失败，请稍后再试");
+        }
+    }
+
+    private String buildSubject(VerificationPurpose purpose) {
+        return switch (purpose) {
+            case REGISTER -> "【EvolutionAI】注册验证码";
+            case RESET_PASSWORD -> "【EvolutionAI】密码重置验证码";
+        };
+    }
+
+    private String buildBody(String code, Duration ttl) {
+        long minutes = Math.max(1, ttl.toMinutes());
+        return String.format("您的验证码为 %s ，有效期 %d 分钟。如非本人操作，请忽略本邮件。", code, minutes);
+    }
+}

--- a/src/main/java/com/example/grpcdemo/auth/VerificationCodeSender.java
+++ b/src/main/java/com/example/grpcdemo/auth/VerificationCodeSender.java
@@ -1,0 +1,24 @@
+package com.example.grpcdemo.auth;
+
+import java.time.Duration;
+
+/**
+ * Abstraction for delivering verification codes to users.
+ */
+public interface VerificationCodeSender {
+
+    /**
+     * Sends a verification code to the user.
+     *
+     * @param email   target email address
+     * @param code    generated verification code
+     * @param role    user role associated with the request
+     * @param purpose purpose of the verification code
+     * @param ttl     validity duration of the verification code
+     */
+    void sendVerificationCode(String email,
+                              String code,
+                              AuthRole role,
+                              VerificationPurpose purpose,
+                              Duration ttl);
+}

--- a/src/main/java/com/example/grpcdemo/controller/AuthController.java
+++ b/src/main/java/com/example/grpcdemo/controller/AuthController.java
@@ -5,7 +5,7 @@ import com.example.grpcdemo.auth.AuthRole;
 import com.example.grpcdemo.controller.dto.AuthResponseDto;
 import com.example.grpcdemo.controller.dto.LoginRequest;
 import com.example.grpcdemo.controller.dto.RegisterRequest;
-import com.example.grpcdemo.controller.dto.SendCodeRequest;
+import com.example.grpcdemo.controller.dto.SendVerificationCodeRequest;
 import com.example.grpcdemo.controller.dto.ResetPasswordRequest;
 import com.example.grpcdemo.controller.dto.SuccessResponse;
 import com.example.grpcdemo.controller.dto.VerificationCodeResponseDto;
@@ -26,14 +26,24 @@ public class AuthController {
         this.authManager = authManager;
     }
 
+    @PostMapping("/{segment}/auth/register/send-code")
+    public VerificationCodeResponseDto sendRegisterCode(@PathVariable("segment") String segment,
+                                                        @Valid @RequestBody SendVerificationCodeRequest request) {
+        AuthRole role = resolveRole(segment);
+        AuthManager.VerificationResult result = authManager.requestRegistrationCode(
+                request.getEmail(),
+                role
+        );
+        return new VerificationCodeResponseDto(result.requestId(), result.expiresInSeconds());
+    }
+
     @PostMapping("/{segment}/auth/password/reset/send-code")
     public VerificationCodeResponseDto sendResetCode(@PathVariable("segment") String segment,
-                                                     @Valid @RequestBody SendCodeRequest request) {
+                                                     @Valid @RequestBody SendVerificationCodeRequest request) {
         AuthRole role = resolveRole(segment);
-        AuthManager.VerificationResult result = authManager.requestVerificationCode(
+        AuthManager.VerificationResult result = authManager.requestPasswordResetCode(
                 request.getEmail(),
-                role,
-                request.getPurpose()
+                role
         );
         return new VerificationCodeResponseDto(result.requestId(), result.expiresInSeconds());
     }

--- a/src/main/java/com/example/grpcdemo/controller/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/ResetPasswordRequest.java
@@ -1,5 +1,7 @@
 package com.example.grpcdemo.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -17,6 +19,9 @@ public class ResetPasswordRequest {
     @NotBlank(message = "新密码不能为空")
     @Size(min = 6, message = "密码至少需要6位")
     private String newPassword;
+
+    @NotBlank(message = "确认密码不能为空")
+    private String confirmPassword;
 
     public String getEmail() {
         return email;
@@ -40,5 +45,22 @@ public class ResetPasswordRequest {
 
     public void setNewPassword(String newPassword) {
         this.newPassword = newPassword;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public void setConfirmPassword(String confirmPassword) {
+        this.confirmPassword = confirmPassword;
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "两次输入的密码不一致")
+    public boolean isPasswordConfirmed() {
+        if (newPassword == null || confirmPassword == null) {
+            return false;
+        }
+        return newPassword.equals(confirmPassword);
     }
 }

--- a/src/main/java/com/example/grpcdemo/controller/dto/SendVerificationCodeRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/SendVerificationCodeRequest.java
@@ -1,0 +1,22 @@
+package com.example.grpcdemo.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 通用的验证码发送请求，仅包含邮箱字段。
+ */
+public class SendVerificationCodeRequest {
+
+    @NotBlank(message = "邮箱不能为空")
+    @Email(message = "邮箱格式不正确")
+    private String email;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure password reset code requests enforce registered users and deliver emails through a dedicated sender
- add reusable verification code sender abstraction backed by Spring Mail
- require password confirmation in reset requests to guard against mismatched inputs
- expose a registration verification code endpoint that reuses the shared email-only request DTO

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central access forbidden in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d75e2c3ed0833181fd480bb968c5c8