### PR TITLE
Align schema with onboarding entities and enhance login accounts

### DIFF
--- a/docs/supabase-migrations.md
+++ b/docs/supabase-migrations.md
@@ -8,15 +8,21 @@
 
 | Java 类型 | 表 | 作用 |
 |-----------|----|------|
-| `UserAccountEntity` | `public.user_accounts` | 存储注册的登录账号。代码需要 `username`、`password_hash` 和 `role` 字段，并在 `(username, role)` 上设置唯一约束。 |
-| `Job` | `app_public.jobs` | 表示通过 gRPC job 服务对外暴露的职位信息。 |
-| `Candidate` | `app_public.candidates` | 表示导入系统的候选人。 |
-| `Interview` | `app_public.interviews` | 将候选人与职位关联，并保存面试的排期状态。 |
-| `ReportEntity` | `app_public.reports` | 保存完成面试后的 AI 评估结果。 |
+| `UserAccountEntity` | `public.user_accounts` | 存储注册的登录账号。字段包含登录邮箱 `email`、`password_hash`、`role`、`status`（`ACTIVE/PENDING/LOCKED`）以及最近登录时间 `last_login_at`，邮箱字段全局唯一。 |
+| `CompanyProfileEntity` | `public.company_profiles` | 保存企业引导完成后的主体信息，包括企业规模、所在地等。 |
+| `CompanyContactEntity` | `public.company_contacts` | 保存企业 HR 联系人及其电话、邮箱等信息。 |
+| `InvitationTemplateEntity` | `public.invitation_templates` | 保存企业配置的邀约邮件模版，并通过部分唯一索引保证每个企业只有一个默认模版。 |
+| `VerificationTokenEntity` | `public.verification_tokens` | 保存企业引导流程中发送的验证码，索引覆盖 `(target_user_id, purpose, code, consumed)` 以支撑查询。 |
+| `Job` | `public.jobs` | 表示通过 gRPC job 服务对外暴露的职位信息。 |
+| `Candidate` | `public.candidates` | 表示导入系统的候选人。 |
+| `Interview` | `public.interviews` | 将候选人与职位关联，并保存面试的排期状态。 |
+| `ReportEntity` | `public.reports` | 保存完成面试后的 AI 评估结果。 |
 
 字段类型、长度限制以及约束定义都在 [`db/schema.sql`](../db/schema.sql) 中给出。
 
-> **登录模块如何落地？** 上表中的 `public.user_accounts` 承担了注册与登录所需的全部字段（用户名、哈希后的密码、角色及审计时间戳），其结构与 Spring Security/JPA 中的 `UserAccountEntity` 一一对应。脚本还包含触发器 `set_user_accounts_updated_at` 用于维护更新时间戳；执行 `db/schema.sql` 后就具备了后端代码完成注册、鉴权的最低要求，不需要额外手动建表。
+> **登录模块如何落地？** `public.user_accounts` 承担了注册与登录所需的全部字段（邮箱、哈希后的密码、角色、账号状态、最近登录时间及审计时间戳），其结构与 Spring Security/JPA 中的 `UserAccountEntity` 一一对应。脚本同时会创建 `set_user_accounts_updated_at` 触发器来维护更新时间戳；执行 `db/schema.sql` 后就具备了后端代码完成注册、鉴权的最低要求。
+
+> **企业引导如何持久化？** `public.company_profiles`、`public.company_contacts`、`public.invitation_templates` 与 `public.verification_tokens` 共同覆盖引导流程落库所需的全部字段。触发器会自动维护 `updated_at` 字段，索引保证查询效率，并利用部分唯一索引确保企业默认模版唯一。
 
 ## 应用数据库结构
 
@@ -33,7 +39,7 @@
 
 你也可以打开 Supabase SQL 编辑器，粘贴 `db/schema.sql` 的内容来手动创建这些数据表。
 
-> **注意权限问题**：Supabase 的 `auth` schema 由平台内部管理，普通数据库角色（如 `postgres`、`service_role`）默认没有在该 schema 下创建表或函数的权限。如果执行旧版本的脚本出现 `permission denied for schema auth`，请改用当前版本的 `db/schema.sql`，它会在 `public` 与 `app_public` schema 中创建业务所需的对象。
+> **注意权限问题**：Supabase 的 `auth` schema 由平台内部管理，普通数据库角色（如 `postgres`、`service_role`）默认没有在该 schema 下创建表或函数的权限。如果执行旧版本的脚本出现 `permission denied for schema auth`，请改用当前版本的 `db/schema.sql`，它只会在 `public` schema 中创建业务所需的对象。
 
 ## 使用迁移跟踪后续变更
 

--- a/src/main/java/com/example/grpcdemo/entity/UserAccountEntity.java
+++ b/src/main/java/com/example/grpcdemo/entity/UserAccountEntity.java
@@ -2,22 +2,26 @@ package com.example.grpcdemo.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+
+import java.time.Instant;
 
 /**
  * JPA entity representing a registered user account.
  */
 @Entity
-@Table(name = "user_accounts", uniqueConstraints = @UniqueConstraint(columnNames = {"username", "role"}))
+@Table(name = "user_accounts", uniqueConstraints = @UniqueConstraint(columnNames = {"email"}))
 public class UserAccountEntity {
 
     @Id
     private String userId;
 
-    @Column(nullable = false)
-    private String username;
+    @Column(name = "email", nullable = false)
+    private String email;
 
     @Column(nullable = false)
     private String passwordHash;
@@ -25,14 +29,36 @@ public class UserAccountEntity {
     @Column(nullable = false)
     private String role;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private UserAccountStatus status = UserAccountStatus.PENDING;
+
+    @Column(name = "last_login_at")
+    private Instant lastLoginAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false, updatable = false, insertable = false)
+    private Instant updatedAt;
+
     public UserAccountEntity() {
     }
 
-    public UserAccountEntity(String userId, String username, String passwordHash, String role) {
+    public UserAccountEntity(String userId, String email, String passwordHash, String role) {
+        this(userId, email, passwordHash, role, UserAccountStatus.PENDING);
+    }
+
+    public UserAccountEntity(String userId,
+                             String email,
+                             String passwordHash,
+                             String role,
+                             UserAccountStatus status) {
         this.userId = userId;
-        this.username = username;
+        this.email = email;
         this.passwordHash = passwordHash;
         this.role = role;
+        this.status = status;
     }
 
     public String getUserId() {
@@ -43,12 +69,12 @@ public class UserAccountEntity {
         this.userId = userId;
     }
 
-    public String getUsername() {
-        return username;
+    public String getEmail() {
+        return email;
     }
 
-    public void setUsername(String username) {
-        this.username = username;
+    public void setEmail(String email) {
+        this.email = email;
     }
 
     public String getPasswordHash() {
@@ -65,5 +91,29 @@ public class UserAccountEntity {
 
     public void setRole(String role) {
         this.role = role;
+    }
+
+    public UserAccountStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(UserAccountStatus status) {
+        this.status = status;
+    }
+
+    public Instant getLastLoginAt() {
+        return lastLoginAt;
+    }
+
+    public void setLastLoginAt(Instant lastLoginAt) {
+        this.lastLoginAt = lastLoginAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
     }
 }

--- a/src/main/java/com/example/grpcdemo/entity/UserAccountStatus.java
+++ b/src/main/java/com/example/grpcdemo/entity/UserAccountStatus.java
@@ -1,0 +1,10 @@
+package com.example.grpcdemo.entity;
+
+/**
+ * Account lifecycle states for registered users.
+ */
+public enum UserAccountStatus {
+    ACTIVE,
+    PENDING,
+    LOCKED
+}

--- a/src/main/java/com/example/grpcdemo/repository/UserAccountRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/UserAccountRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
  */
 public interface UserAccountRepository extends JpaRepository<UserAccountEntity, String> {
 
-    Optional<UserAccountEntity> findByUsernameAndRole(String username, String role);
+    Optional<UserAccountEntity> findByEmailAndRole(String email, String role);
 }

--- a/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/grpcdemo/service/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.grpcdemo.service;
 
 import com.example.grpcdemo.entity.UserAccountEntity;
+import com.example.grpcdemo.entity.UserAccountStatus;
 import com.example.grpcdemo.proto.AuthServiceGrpc;
 import com.example.grpcdemo.proto.LoginRequest;
 import com.example.grpcdemo.proto.RegisterUserRequest;
@@ -13,6 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.Instant;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -34,18 +37,19 @@ public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
 
     @Override
     public void registerUser(RegisterUserRequest request, StreamObserver<UserResponse> responseObserver) {
-        String username = request.getUsername().trim();
+        String email = request.getEmail().isBlank() ? request.getUsername().trim() : request.getEmail().trim();
         String password = request.getPassword();
         String role = request.getRole().trim();
+        String normalizedRole = role.toLowerCase(Locale.ROOT);
 
-        if (username.isEmpty() || password.isEmpty() || role.isEmpty()) {
+        if (email.isEmpty() || password.isEmpty() || role.isEmpty()) {
             responseObserver.onError(Status.INVALID_ARGUMENT
-                    .withDescription("Username, password and role are required")
+                    .withDescription("Email, password and role are required")
                     .asRuntimeException());
             return;
         }
 
-        Optional<UserAccountEntity> existing = userRepository.findByUsernameAndRole(username, role);
+        Optional<UserAccountEntity> existing = userRepository.findByEmailAndRole(email, normalizedRole);
         if (existing.isPresent()) {
             responseObserver.onError(Status.ALREADY_EXISTS
                     .withDescription("User already exists")
@@ -55,9 +59,9 @@ public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
 
         String userId = UUID.randomUUID().toString();
         String hashedPassword = passwordEncoder.encode(password);
-        UserAccountEntity entity = new UserAccountEntity(userId, username, hashedPassword, role);
+        UserAccountEntity entity = new UserAccountEntity(userId, email, hashedPassword, normalizedRole, UserAccountStatus.ACTIVE);
         userRepository.save(entity);
-        log.info("Registered new user: username={}, role={}", username, role);
+        log.info("Registered new user: email={}, role={}", email, normalizedRole);
 
         responseObserver.onNext(toResponse(entity));
         responseObserver.onCompleted();
@@ -65,37 +69,45 @@ public class AuthServiceImpl extends AuthServiceGrpc.AuthServiceImplBase {
 
     @Override
     public void loginUser(LoginRequest request, StreamObserver<UserResponse> responseObserver) {
-        String username = request.getUsername().trim();
+        String email = request.getUsername().trim();
         String password = request.getPassword();
         String role = request.getRole().trim();
+        String normalizedRole = role.toLowerCase(Locale.ROOT);
 
-        if (username.isEmpty() || password.isEmpty() || role.isEmpty()) {
+        if (email.isEmpty() || password.isEmpty() || role.isEmpty()) {
             responseObserver.onError(Status.INVALID_ARGUMENT
-                    .withDescription("Username, password and role are required")
+                    .withDescription("Email, password and role are required")
                     .asRuntimeException());
             return;
         }
 
-        Optional<UserAccountEntity> existing = userRepository.findByUsernameAndRole(username, role);
+        Optional<UserAccountEntity> existing = userRepository.findByEmailAndRole(email, normalizedRole);
         if (existing.isEmpty() || !passwordEncoder.matches(password, existing.get().getPasswordHash())) {
             responseObserver.onError(Status.UNAUTHENTICATED
-                    .withDescription("Invalid username or password")
+                    .withDescription("Invalid email or password")
                     .asRuntimeException());
             return;
         }
 
-        responseObserver.onNext(toResponse(existing.get()));
+        UserAccountEntity entity = existing.get();
+        entity.setLastLoginAt(Instant.now());
+        if (entity.getStatus() == UserAccountStatus.PENDING) {
+            entity.setStatus(UserAccountStatus.ACTIVE);
+        }
+        userRepository.save(entity);
+
+        responseObserver.onNext(toResponse(entity));
         responseObserver.onCompleted();
     }
 
     private UserResponse toResponse(UserAccountEntity entity) {
-        String accessToken = JwtUtil.generateToken(entity.getUserId(), entity.getUsername(), entity.getRole());
+        String accessToken = JwtUtil.generateToken(entity.getUserId(), entity.getEmail(), entity.getRole());
         String refreshToken = UUID.randomUUID().toString();
         return UserResponse.newBuilder()
                 .setUserId(entity.getUserId())
-                .setUsername(entity.getUsername())
+                .setUsername(entity.getEmail())
                 .setRole(entity.getRole())
-                .setEmail(entity.getUsername())
+                .setEmail(entity.getEmail())
                 .setAccessToken(accessToken)
                 .setRefreshToken(refreshToken)
                 .build();

--- a/src/main/java/com/example/grpcdemo/service/JwtUtil.java
+++ b/src/main/java/com/example/grpcdemo/service/JwtUtil.java
@@ -20,10 +20,10 @@ public final class JwtUtil {
     private JwtUtil() {
     }
 
-    public static String generateToken(String userId, String username, String role) {
+    public static String generateToken(String userId, String email, String role) {
         return JWT.create()
                 .withSubject(userId)
-                .withClaim("username", username)
+                .withClaim("email", email)
                 .withClaim("role", role)
                 .withExpiresAt(Date.from(Instant.now().plusSeconds(3600)))
                 .sign(ALGORITHM);

--- a/src/test/java/com/example/grpcdemo/service/AuthServiceImplTest.java
+++ b/src/test/java/com/example/grpcdemo/service/AuthServiceImplTest.java
@@ -53,7 +53,7 @@ class AuthServiceImplTest {
         UserResponse registered = registerObserver.getValues().get(0);
         assertThat(registered.getUserId()).isNotBlank();
         assertThat(registered.getUsername()).isEqualTo("valid-user");
-        assertThat(registered.getRole()).isEqualTo("ADMIN");
+        assertThat(registered.getRole()).isEqualTo("admin");
 
         userRepository.flush();
         UserAccountEntity persisted =
@@ -78,7 +78,7 @@ class AuthServiceImplTest {
         UserResponse loginResponse = loginObserver.getValues().get(0);
         assertThat(loginResponse.getUserId()).isEqualTo(registered.getUserId());
         assertThat(loginResponse.getUsername()).isEqualTo("valid-user");
-        assertThat(loginResponse.getRole()).isEqualTo("ADMIN");
+        assertThat(loginResponse.getRole()).isEqualTo("admin");
         assertThat(loginResponse.getAccessToken()).isNotBlank();
     }
 
@@ -87,7 +87,7 @@ class AuthServiceImplTest {
         RegisterUserRequest registerRequest = RegisterUserRequest.newBuilder()
                 .setUsername("invalid-user")
                 .setPassword("correct-password")
-                .setRole("USER")
+                .setRole("COMPANY")
                 .build();
 
         TestStreamObserver<UserResponse> registerObserver = new TestStreamObserver<>();
@@ -98,7 +98,7 @@ class AuthServiceImplTest {
         LoginRequest loginRequest = LoginRequest.newBuilder()
                 .setUsername("invalid-user")
                 .setPassword("wrong-password")
-                .setRole("USER")
+                .setRole("COMPANY")
                 .build();
 
         authService.loginUser(loginRequest, loginObserver);
@@ -115,7 +115,7 @@ class AuthServiceImplTest {
         RegisterUserRequest registerRequest = RegisterUserRequest.newBuilder()
                 .setUsername("duplicate-user")
                 .setPassword("password")
-                .setRole("USER")
+                .setRole("ENGINEER")
                 .build();
 
         TestStreamObserver<UserResponse> firstObserver = new TestStreamObserver<>();

--- a/技术接口文档&数据库基本结构.md
+++ b/技术接口文档&数据库基本结构.md
@@ -13,9 +13,9 @@
     user表
   | 字段                          | 类型                                | 说明        |
   | `id`                        | UUID                              | 主键        |
-  | `email`                     | VARCHAR(255) UNIQUE               | 登录邮箱      |
+  | `email`                     | CITEXT UNIQUE                     | 登录邮箱（忽略大小写） |
   | `password_hash`             | VARCHAR                           | BCrypt 哈希 |
-  | `role`                      | ENUM(ENTERPRISE, ENGINEER, ADMIN) | 角色        |
+  | `role`                      | ENUM(company, engineer, admin)   | 角色（与接口中的 role 参数一致） |
   | `status`                    | ENUM(ACTIVE, PENDING, LOCKED)     | 状态        |
   | `created_at` / `updated_at` | TIMESTAMP                         | 创建/更新时间   |
   | `last_login_at`             | TIMESTAMP                         | 最近登录      |


### PR DESCRIPTION
## Summary
- update db/schema.sql to store login emails with account status/last login fields and broadened role checks, plus refresh Supabase docs
- align authentication entities, repository methods, and service logic around email-based logins while tracking status transitions
- adjust tests and technical database docs to reflect case-insensitive emails and normalized role values

## Testing
- mvn -q test *(fails: Maven Central returns 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68da5d6e8730833183fed77866eb597a