### PR TITLE
Support Accept-Language aware onboarding templates

### DIFF
--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -152,8 +152,16 @@ All requests/响应均为 JSON，所有字段都带有后端校验（邮箱格�
 
 ### 4. 步骤三：面试邀约模版
 - **Endpoint**：`POST /api/enterprise/onboarding/step3`
-- **Request body** (`EnterpriseStep3Request`): `userId`、`templateName`、`subject`、`body` 必填，`language` 默认 `zh-CN`。
-- **行为说明**：后台会解析正文/主题中的 `[[...]]` 变量，限制只能使用以下字段：`[[候选人姓名]]`、`[[岗位名称]]`、`[[企业全称]]`、`[[面试时间]]`、`[[面试地点]]`、`[[面试链接]]`、`[[联系人姓名]]`、`[[联系人电话]]`、`[[联系人邮箱]]`。超出范围将返回 `INVALID_TEMPLATE_VARIABLE`。保存成功后 `currentStep`=4，供验证码页面使用。【F:src/main/java/com/example/grpcdemo/controller/dto/EnterpriseStep3Request.java†L14-L67】【F:src/main/java/com/example/grpcdemo/service/EnterpriseOnboardingService.java†L148-L185】【F:src/main/java/com/example/grpcdemo/service/EnterpriseOnboardingService.java†L49-L63】【F:src/main/java/com/example/grpcdemo/service/EnterpriseOnboardingService.java†L420-L449】
+- **Request body** (`EnterpriseStep3Request`): `userId`、`templateName`、`subject`、`body` 必填，`language` 默认 `zh`，与前端的 `Accept-Language` 请求头保持一致（支持 `zh`/`en`/`jp`，若字段为空则按请求头或中文兜底）。
+- **行为说明**：后台会解析正文/主题中的 `[[...]]` 变量，并根据当前语言校验允许的占位符。支持的变量如下表，发送其他占位符会返回 `INVALID_TEMPLATE_VARIABLE`：
+
+  | 语言 (`Accept-Language`) | 允许的占位符 |
+  | ----------------------- | ------------ |
+  | `zh` | `[[候选人姓名]]`、`[[岗位名称]]`、`[[企业全称]]`、`[[面试时间]]`、`[[面试地点]]`、`[[面试链接]]`、`[[联系人姓名]]`、`[[联系人电话]]`、`[[联系人邮箱]]` |
+  | `en` | `[[Candidate Name]]`、`[[Job Title]]`、`[[Company Name]]`、`[[Interview Time]]`、`[[Interview Location]]`、`[[Interview Link]]`、`[[Contact Name]]`、`[[Contact Phone]]`、`[[Contact Email]]` |
+  | `jp` | `[[候補者名]]`、`[[職位名]]`、`[[企業名]]`、`[[面接時間]]`、`[[面接場所]]`、`[[面接リンク]]`、`[[担当者名]]`、`[[担当者電話]]`、`[[担当者メール]]` |
+
+  后端在所有 `OnboardingStateResponse` 响应中会根据 `Accept-Language` 请求头返回匹配语言的 `availableVariables` 列表，便于前端渲染按钮。保存成功后 `currentStep`=4，供验证码页面使用。【F:src/main/java/com/example/grpcdemo/controller/dto/EnterpriseStep3Request.java†L14-L67】【F:src/main/java/com/example/grpcdemo/controller/EnterpriseOnboardingController.java†L27-L55】【F:src/main/java/com/example/grpcdemo/service/EnterpriseOnboardingService.java†L62-L339】【F:src/main/java/com/example/grpcdemo/service/EnterpriseOnboardingService.java†L362-L608】
 
 ### 5. 最终校验并入库
 - **Endpoint**：`POST /api/enterprise/onboarding/verify`

--- a/src/main/java/com/example/grpcdemo/controller/EnterpriseOnboardingController.java
+++ b/src/main/java/com/example/grpcdemo/controller/EnterpriseOnboardingController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,27 +29,32 @@ public class EnterpriseOnboardingController {
     }
 
     @GetMapping("/state")
-    public OnboardingStateResponse getState(@RequestParam("userId") String userId) {
-        return onboardingService.getState(userId);
+    public OnboardingStateResponse getState(@RequestParam("userId") String userId,
+                                            @RequestHeader(value = "Accept-Language", required = false) String acceptLanguage) {
+        return onboardingService.getState(userId, acceptLanguage);
     }
 
     @PostMapping("/step1")
-    public OnboardingStateResponse saveStep1(@Valid @RequestBody EnterpriseStep1Request request) {
-        return onboardingService.saveStep1(request);
+    public OnboardingStateResponse saveStep1(@Valid @RequestBody EnterpriseStep1Request request,
+                                            @RequestHeader(value = "Accept-Language", required = false) String acceptLanguage) {
+        return onboardingService.saveStep1(request, acceptLanguage);
     }
 
     @PostMapping("/step2")
-    public OnboardingStateResponse saveStep2(@Valid @RequestBody EnterpriseStep2Request request) {
-        return onboardingService.saveStep2(request);
+    public OnboardingStateResponse saveStep2(@Valid @RequestBody EnterpriseStep2Request request,
+                                            @RequestHeader(value = "Accept-Language", required = false) String acceptLanguage) {
+        return onboardingService.saveStep2(request, acceptLanguage);
     }
 
     @PostMapping("/step3")
-    public OnboardingStateResponse saveStep3(@Valid @RequestBody EnterpriseStep3Request request) {
-        return onboardingService.saveStep3(request);
+    public OnboardingStateResponse saveStep3(@Valid @RequestBody EnterpriseStep3Request request,
+                                            @RequestHeader(value = "Accept-Language", required = false) String acceptLanguage) {
+        return onboardingService.saveStep3(request, acceptLanguage);
     }
 
     @PostMapping("/verify")
-    public OnboardingStateResponse verify(@Valid @RequestBody EnterpriseVerifyRequest request) {
-        return onboardingService.verifyAndComplete(request);
+    public OnboardingStateResponse verify(@Valid @RequestBody EnterpriseVerifyRequest request,
+                                         @RequestHeader(value = "Accept-Language", required = false) String acceptLanguage) {
+        return onboardingService.verifyAndComplete(request, acceptLanguage);
     }
 }

--- a/src/main/java/com/example/grpcdemo/controller/dto/EnterpriseStep3Request.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/EnterpriseStep3Request.java
@@ -24,7 +24,7 @@ public class EnterpriseStep3Request {
     private String body;
 
     @Size(max = 32, message = "语言标识长度需小于 32 个字符")
-    private String language = "zh-CN";
+    private String language = "zh";
 
     public String getUserId() {
         return userId;

--- a/技术接口文档&数据库基本结构.md
+++ b/技术接口文档&数据库基本结构.md
@@ -74,7 +74,7 @@
       | `template_name` | VARCHAR(255)   | 模版名称 |
       | `subject`       | VARCHAR(255)   | 邮件主题 |
       | `body`          | VARCHAR(5000)  | 邮件正文（可包含变量占位符）|
-      | `language`      | VARCHAR(32)    | 语言标识，默认 `zh-CN` |
+      | `language`      | VARCHAR(32)    | 语言标识，默认 `zh`（支持 `zh`/`en`/`jp`） |
       | `is_default`    | BOOLEAN        | 是否为默认模版 |
       | `created_at`/`updated_at` | TIMESTAMP | 审计字段 |
     verification_tokens 表（验证码记录）


### PR DESCRIPTION
## Summary
- align onboarding template language defaults with the front-end Accept-Language header (`zh`/`en`/`jp`)
- validate template placeholders per language and return localized availableVariables in onboarding responses
- document the multi-language behavior in the integration guides and data dictionary

## Testing
- ./mvnw -q -DskipTests package *(fails: Maven download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ddfd528f74833197fdc7550825769e