### PR TITLE
Replace nv-i18n usage with internal location catalog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,13 +127,6 @@
             <version>4.4.0</version>
         </dependency>
 
-        <!-- ISO country & subdivision catalog -->
-        <dependency>
-            <groupId>com.neovisionaries</groupId>
-            <artifactId>nv-i18n</artifactId>
-            <version>1.29</version>
-        </dependency>
-
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/grpcdemo/location/LocationCatalog.java
+++ b/src/main/java/com/example/grpcdemo/location/LocationCatalog.java
@@ -1,17 +1,17 @@
 package com.example.grpcdemo.location;
 
-import com.neovisionaries.i18n.CountryCode;
-import com.neovisionaries.i18n.Subdivision;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -20,20 +20,22 @@ import java.util.stream.Collectors;
 @Component
 public class LocationCatalog {
 
-    private final Map<String, List<LocationOption>> subdivisionCache = new ConcurrentHashMap<>();
+    private static final Set<String> ISO_COUNTRY_CODES = Arrays.stream(Locale.getISOCountries())
+            .map(code -> code.toUpperCase(Locale.ROOT))
+            .collect(Collectors.toUnmodifiableSet());
+
+    private static final Map<String, List<LocalizedSubdivision>> SUBDIVISION_CATALOG = createSubdivisionCatalog();
 
     public List<LocationOption> getCountries(Locale locale) {
         Locale displayLocale = locale != null ? locale : Locale.SIMPLIFIED_CHINESE;
         List<LocationOption> options = new ArrayList<>();
-        for (CountryCode code : CountryCode.values()) {
-            if (!code.isAssigned()) {
+        for (String code : ISO_COUNTRY_CODES) {
+            Locale countryLocale = new Locale("", code);
+            String name = countryLocale.getDisplayCountry(displayLocale);
+            if (name == null || name.isBlank()) {
                 continue;
             }
-            String alpha2 = code.getAlpha2();
-            if (alpha2 == null) {
-                continue;
-            }
-            options.add(new LocationOption(alpha2, code.getName(displayLocale)));
+            options.add(new LocationOption(code, name));
         }
         options.sort(Comparator.comparing(LocationOption::name, String.CASE_INSENSITIVE_ORDER));
         return Collections.unmodifiableList(options);
@@ -43,22 +45,14 @@ public class LocationCatalog {
         if (countryCode == null) {
             return Collections.emptyList();
         }
-        CountryCode code = CountryCode.getByCode(countryCode.toUpperCase(Locale.ROOT));
-        if (code == null || !code.isAssigned()) {
+        String normalizedCountry = countryCode.toUpperCase(Locale.ROOT);
+        List<LocalizedSubdivision> subdivisions = SUBDIVISION_CATALOG.get(normalizedCountry);
+        if (subdivisions == null || subdivisions.isEmpty()) {
             return Collections.emptyList();
         }
-        List<LocationOption> cached = subdivisionCache.computeIfAbsent(code.getAlpha2(), key -> {
-            List<Subdivision> subdivisions = code.getSubdivisionList();
-            if (subdivisions == null) {
-                return new ArrayList<>();
-            }
-            return subdivisions.stream()
-                    .map(subdivision -> new LocationOption(subdivision.getCode(), subdivision.getName()))
-                    .collect(Collectors.toCollection(ArrayList::new));
-        });
         Locale displayLocale = locale != null ? locale : Locale.SIMPLIFIED_CHINESE;
-        return cached.stream()
-                .map(option -> new LocationOption(option.code(), localizeSubdivision(option.code(), displayLocale)))
+        return subdivisions.stream()
+                .map(subdivision -> new LocationOption(subdivision.code(), subdivision.displayName(displayLocale)))
                 .sorted(Comparator.comparing(LocationOption::name, String.CASE_INSENSITIVE_ORDER))
                 .collect(Collectors.toUnmodifiableList());
     }
@@ -67,58 +61,79 @@ public class LocationCatalog {
         if (countryCode == null) {
             return Optional.empty();
         }
-        CountryCode code = CountryCode.getByCode(countryCode.toUpperCase(Locale.ROOT));
-        if (code == null || !code.isAssigned()) {
+        String normalizedCountry = countryCode.toUpperCase(Locale.ROOT);
+        if (!ISO_COUNTRY_CODES.contains(normalizedCountry)) {
             return Optional.empty();
         }
         Locale displayLocale = locale != null ? locale : Locale.SIMPLIFIED_CHINESE;
-        return Optional.of(new LocationOption(code.getAlpha2(), code.getName(displayLocale)));
+        Locale countryLocale = new Locale("", normalizedCountry);
+        return Optional.of(new LocationOption(normalizedCountry, countryLocale.getDisplayCountry(displayLocale)));
     }
 
     public Optional<LocationOption> findCity(String countryCode, String subdivisionCode, Locale locale) {
         if (countryCode == null || subdivisionCode == null) {
             return Optional.empty();
         }
-        CountryCode code = CountryCode.getByCode(countryCode.toUpperCase(Locale.ROOT));
-        if (code == null || !code.isAssigned()) {
+        String normalizedCountry = countryCode.toUpperCase(Locale.ROOT);
+        List<LocalizedSubdivision> subdivisions = SUBDIVISION_CATALOG.get(normalizedCountry);
+        if (subdivisions == null || subdivisions.isEmpty()) {
             return Optional.empty();
         }
         String normalizedSubdivision = subdivisionCode.toUpperCase(Locale.ROOT);
-        List<Subdivision> subdivisions = code.getSubdivisionList();
-        if (subdivisions == null) {
-            return Optional.empty();
-        }
-        for (Subdivision subdivision : subdivisions) {
-            if (normalizedSubdivision.equalsIgnoreCase(subdivision.getCode())) {
-                Locale displayLocale = locale != null ? locale : Locale.SIMPLIFIED_CHINESE;
-                return Optional.of(new LocationOption(subdivision.getCode(),
-                        subdivision.getName(displayLocale)));
-            }
-        }
-        return Optional.empty();
-    }
-
-    private String localizeSubdivision(String subdivisionCode, Locale locale) {
-        String[] segments = subdivisionCode.split("-");
-        if (segments.length != 2) {
-            return subdivisionCode;
-        }
-        CountryCode country = CountryCode.getByCode(segments[0]);
-        if (country == null) {
-            return subdivisionCode;
-        }
-        List<Subdivision> subdivisions = country.getSubdivisionList();
-        if (subdivisions == null) {
-            return subdivisionCode;
-        }
-        for (Subdivision subdivision : subdivisions) {
-            if (subdivision.getCode().equalsIgnoreCase(subdivisionCode)) {
-                return subdivision.getName(locale != null ? locale : Locale.SIMPLIFIED_CHINESE);
-            }
-        }
-        return subdivisionCode;
+        Locale displayLocale = locale != null ? locale : Locale.SIMPLIFIED_CHINESE;
+        return subdivisions.stream()
+                .filter(subdivision -> subdivision.code().equalsIgnoreCase(normalizedSubdivision))
+                .findFirst()
+                .map(subdivision -> new LocationOption(subdivision.code(), subdivision.displayName(displayLocale)));
     }
 
     public record LocationOption(String code, String name) {
+    }
+
+    private static Map<String, List<LocalizedSubdivision>> createSubdivisionCatalog() {
+        Map<String, List<LocalizedSubdivision>> catalog = new LinkedHashMap<>();
+        catalog.put("CN", List.of(
+                new LocalizedSubdivision("CN-AH", "Anhui", "安徽省"),
+                new LocalizedSubdivision("CN-BJ", "Beijing", "北京市"),
+                new LocalizedSubdivision("CN-GD", "Guangdong", "广东省"),
+                new LocalizedSubdivision("CN-SH", "Shanghai", "上海市"),
+                new LocalizedSubdivision("CN-SC", "Sichuan", "四川省"),
+                new LocalizedSubdivision("CN-ZJ", "Zhejiang", "浙江省")
+        ));
+        catalog.put("US", List.of(
+                new LocalizedSubdivision("US-CA", "California", "加利福尼亚州"),
+                new LocalizedSubdivision("US-NY", "New York", "纽约州"),
+                new LocalizedSubdivision("US-TX", "Texas", "得克萨斯州"),
+                new LocalizedSubdivision("US-WA", "Washington", "华盛顿州"),
+                new LocalizedSubdivision("US-FL", "Florida", "佛罗里达州")
+        ));
+        catalog.put("CA", List.of(
+                new LocalizedSubdivision("CA-BC", "British Columbia", "不列颠哥伦比亚省"),
+                new LocalizedSubdivision("CA-ON", "Ontario", "安大略省"),
+                new LocalizedSubdivision("CA-QC", "Quebec", "魁北克省"),
+                new LocalizedSubdivision("CA-AB", "Alberta", "艾伯塔省")
+        ));
+        catalog.put("JP", List.of(
+                new LocalizedSubdivision("JP-13", "Tokyo", "东京都"),
+                new LocalizedSubdivision("JP-27", "Osaka", "大阪府"),
+                new LocalizedSubdivision("JP-23", "Aichi", "爱知县"),
+                new LocalizedSubdivision("JP-01", "Hokkaido", "北海道")
+        ));
+        catalog.put("DE", List.of(
+                new LocalizedSubdivision("DE-BE", "Berlin", "柏林州"),
+                new LocalizedSubdivision("DE-BY", "Bavaria", "巴伐利亚州"),
+                new LocalizedSubdivision("DE-NW", "North Rhine-Westphalia", "北莱茵-威斯特法伦州"),
+                new LocalizedSubdivision("DE-HE", "Hesse", "黑森州")
+        ));
+        return Collections.unmodifiableMap(catalog);
+    }
+
+    private record LocalizedSubdivision(String code, String englishName, String simplifiedChineseName) {
+        String displayName(Locale locale) {
+            if (locale != null && "zh".equalsIgnoreCase(locale.getLanguage()) && simplifiedChineseName != null) {
+                return simplifiedChineseName;
+            }
+            return englishName;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the nv-i18n dependency by using the JDK ISO country list
- ship a curated subdivision catalog with localized names for common regions
- remove the external nv-i18n dependency from the Maven build

## Testing
- ./mvnw -q -DskipTests compile *(fails: repository download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1393eb2c833190ba44ce37c236c0