### PR TITLE
Refactor location catalog to use nv-i18n ISO data

### DIFF
--- a/src/main/java/com/example/grpcdemo/location/LocationCatalog.java
+++ b/src/main/java/com/example/grpcdemo/location/LocationCatalog.java
@@ -1,7 +1,11 @@
 package com.example.grpcdemo.location;
 
+import com.neovisionaries.i18n.CountryCode;
+import com.neovisionaries.i18n.SubdivisionCode;
 import org.springframework.stereotype.Component;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.ReflectiveOperationException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -20,10 +25,15 @@ import java.util.stream.Collectors;
 @Component
 public class LocationCatalog {
 
-    private static final Set<String> ISO_COUNTRY_CODES = Arrays.stream(Locale.getISOCountries())
-            .map(code -> code.toUpperCase(Locale.ROOT))
+    private static final Method COUNTRY_GET_ALPHA2_METHOD = findCountryMethod("getAlpha2");
+    private static final Method COUNTRY_IS_OFFICIALLY_ASSIGNED_METHOD = findCountryMethod("isOfficiallyAssigned");
+    private static final Set<String> ISO_COUNTRY_CODES = Arrays.stream(CountryCode.values())
+            .map(LocationCatalog::alpha2Code)
+            .filter(Objects::nonNull)
             .collect(Collectors.toUnmodifiableSet());
 
+    private static final Method SUBDIVISION_GET_NAME_METHOD = findSubdivisionMethod("getName");
+    private static final Method SUBDIVISION_GET_LOCAL_NAME_METHOD = findSubdivisionMethod("getLocalName");
     private static final Map<String, List<LocalizedSubdivision>> SUBDIVISION_CATALOG = createSubdivisionCatalog();
 
     public List<LocationOption> getCountries(Locale locale) {
@@ -91,49 +101,132 @@ public class LocationCatalog {
     }
 
     private static Map<String, List<LocalizedSubdivision>> createSubdivisionCatalog() {
-        Map<String, List<LocalizedSubdivision>> catalog = new LinkedHashMap<>();
-        catalog.put("CN", List.of(
-                new LocalizedSubdivision("CN-AH", "Anhui", "安徽省"),
-                new LocalizedSubdivision("CN-BJ", "Beijing", "北京市"),
-                new LocalizedSubdivision("CN-GD", "Guangdong", "广东省"),
-                new LocalizedSubdivision("CN-SH", "Shanghai", "上海市"),
-                new LocalizedSubdivision("CN-SC", "Sichuan", "四川省"),
-                new LocalizedSubdivision("CN-ZJ", "Zhejiang", "浙江省")
-        ));
-        catalog.put("US", List.of(
-                new LocalizedSubdivision("US-CA", "California", "加利福尼亚州"),
-                new LocalizedSubdivision("US-NY", "New York", "纽约州"),
-                new LocalizedSubdivision("US-TX", "Texas", "得克萨斯州"),
-                new LocalizedSubdivision("US-WA", "Washington", "华盛顿州"),
-                new LocalizedSubdivision("US-FL", "Florida", "佛罗里达州")
-        ));
-        catalog.put("CA", List.of(
-                new LocalizedSubdivision("CA-BC", "British Columbia", "不列颠哥伦比亚省"),
-                new LocalizedSubdivision("CA-ON", "Ontario", "安大略省"),
-                new LocalizedSubdivision("CA-QC", "Quebec", "魁北克省"),
-                new LocalizedSubdivision("CA-AB", "Alberta", "艾伯塔省")
-        ));
-        catalog.put("JP", List.of(
-                new LocalizedSubdivision("JP-13", "Tokyo", "东京都"),
-                new LocalizedSubdivision("JP-27", "Osaka", "大阪府"),
-                new LocalizedSubdivision("JP-23", "Aichi", "爱知县"),
-                new LocalizedSubdivision("JP-01", "Hokkaido", "北海道")
-        ));
-        catalog.put("DE", List.of(
-                new LocalizedSubdivision("DE-BE", "Berlin", "柏林州"),
-                new LocalizedSubdivision("DE-BY", "Bavaria", "巴伐利亚州"),
-                new LocalizedSubdivision("DE-NW", "North Rhine-Westphalia", "北莱茵-威斯特法伦州"),
-                new LocalizedSubdivision("DE-HE", "Hesse", "黑森州")
-        ));
+        Map<String, List<LocalizedSubdivision>> catalog = Arrays.stream(SubdivisionCode.values())
+                .map(LocationCatalog::toLocalizedSubdivision)
+                .filter(Objects::nonNull)
+                .collect(Collectors.groupingBy(LocalizedSubdivision::countryCode,
+                        LinkedHashMap::new,
+                        Collectors.collectingAndThen(Collectors.toCollection(ArrayList::new), subdivisions -> {
+                            subdivisions.sort(Comparator.comparing(LocalizedSubdivision::englishName, String.CASE_INSENSITIVE_ORDER));
+                            return Collections.unmodifiableList(subdivisions);
+                        })));
         return Collections.unmodifiableMap(catalog);
     }
 
-    private record LocalizedSubdivision(String code, String englishName, String simplifiedChineseName) {
+    private static String alpha2Code(CountryCode countryCode) {
+        if (countryCode == null) {
+            return null;
+        }
+        if (!isOfficiallyAssigned(countryCode)) {
+            return null;
+        }
+        String alpha2 = invokeCountryAlpha2(countryCode);
+        if (alpha2 == null || alpha2.isBlank()) {
+            return null;
+        }
+        String normalized = alpha2.toUpperCase(Locale.ROOT);
+        if (normalized.length() != 2) {
+            return null;
+        }
+        for (int i = 0; i < normalized.length(); i++) {
+            if (!Character.isLetter(normalized.charAt(i))) {
+                return null;
+            }
+        }
+        return normalized;
+    }
+
+    private static LocalizedSubdivision toLocalizedSubdivision(SubdivisionCode subdivisionCode) {
+        if (subdivisionCode == null) {
+            return null;
+        }
+        String isoCode = subdivisionCode.name().replace('_', '-');
+        int separatorIndex = isoCode.indexOf('-');
+        if (separatorIndex <= 0) {
+            return null;
+        }
+        String countryAlpha2 = isoCode.substring(0, separatorIndex);
+        if (!ISO_COUNTRY_CODES.contains(countryAlpha2)) {
+            return null;
+        }
+        String englishName = invokeSubdivisionName(subdivisionCode, SUBDIVISION_GET_NAME_METHOD);
+        if (englishName == null || englishName.isBlank()) {
+            englishName = isoCode;
+        }
+        String localName = invokeSubdivisionName(subdivisionCode, SUBDIVISION_GET_LOCAL_NAME_METHOD);
+        if (localName != null && localName.isBlank()) {
+            localName = null;
+        }
+        return new LocalizedSubdivision(countryAlpha2, isoCode, englishName, localName);
+    }
+
+    private record LocalizedSubdivision(String countryCode, String code, String englishName, String localName) {
         String displayName(Locale locale) {
-            if (locale != null && "zh".equalsIgnoreCase(locale.getLanguage()) && simplifiedChineseName != null) {
-                return simplifiedChineseName;
+            if (locale != null && "zh".equalsIgnoreCase(locale.getLanguage()) && localName != null) {
+                return localName;
             }
             return englishName;
         }
+    }
+
+    private static Method findSubdivisionMethod(String methodName) {
+        try {
+            return SubdivisionCode.class.getMethod(methodName);
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+
+    private static Method findCountryMethod(String methodName) {
+        try {
+            return CountryCode.class.getMethod(methodName);
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+
+    private static boolean isOfficiallyAssigned(CountryCode countryCode) {
+        if (COUNTRY_IS_OFFICIALLY_ASSIGNED_METHOD == null) {
+            return true;
+        }
+        try {
+            Object value = COUNTRY_IS_OFFICIALLY_ASSIGNED_METHOD.invoke(countryCode);
+            if (value instanceof Boolean booleanValue) {
+                return booleanValue;
+            }
+        } catch (ReflectiveOperationException ignored) {
+            return true;
+        }
+        return true;
+    }
+
+    private static String invokeCountryAlpha2(CountryCode countryCode) {
+        if (COUNTRY_GET_ALPHA2_METHOD == null) {
+            return countryCode.name();
+        }
+        try {
+            Object value = COUNTRY_GET_ALPHA2_METHOD.invoke(countryCode);
+            if (value instanceof String stringValue) {
+                return stringValue;
+            }
+        } catch (ReflectiveOperationException ignored) {
+            return countryCode.name();
+        }
+        return countryCode.name();
+    }
+
+    private static String invokeSubdivisionName(SubdivisionCode subdivisionCode, Method method) {
+        if (method == null) {
+            return null;
+        }
+        try {
+            Object value = method.invoke(subdivisionCode);
+            if (value instanceof String stringValue) {
+                return stringValue;
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // Fallback handled by caller.
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- replace the hard coded country and subdivision definitions with ISO data from the nv-i18n library
- dynamically build country and subdivision options, including localized names when available
- keep lookups stable by caching the generated catalogs and normalizing codes

## Testing
- ./mvnw -q -DskipTests package *(fails: dependency download blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1f1244f08331851d216e0948e5f1