### PR TITLE
Fix protobuf plugin configuration to avoid macOS gRPC compilation errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,32 +157,29 @@
     <plugin>
       <groupId>org.xolstice.maven.plugins</groupId>
       <artifactId>protobuf-maven-plugin</artifactId>
-      <version>0.6.1</version>
+      <version>0.7.3</version>
       <configuration>
         <protocArtifact>
           com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
         </protocArtifact>
-        <!--
-          Disable scanning of regular Maven dependencies for *.proto definitions.
-          The project only uses the protobuf files that live under src/main/proto and
-          macOS users reported that the plugin was trying to treat unpacked dependency
-          jars inside target/protoc-dependencies as include directories, causing
-          "Proto path element is not a directory" failures during the second
-          invocation of the compile goal (e.g. when both generate-sources and
-          compile phases are executed in one Maven call).
-        -->
-        <includeDependencies>false</includeDependencies>
-        <pluginId>grpc-java</pluginId>
-        <pluginArtifact>
-          io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
-        </pluginArtifact>
       </configuration>
       <executions>
         <execution>
+          <id>generate-proto-sources</id>
+          <phase>generate-sources</phase>
           <goals>
             <goal>compile</goal>         <!-- 生成 protobuf Java -->
             <goal>compile-custom</goal>  <!-- 生成 gRPC stub -->
           </goals>
+          <configuration>
+            <!-- 只编译工程内的 proto，避免重复扫描依赖 -->
+            <includeDependencies>false</includeDependencies>
+            <cleanOutputDirectories>true</cleanOutputDirectories>
+            <pluginId>grpc-java</pluginId>
+            <pluginArtifact>
+              io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+            </pluginArtifact>
+          </configuration>
         </execution>
       </executions>
     </plugin>


### PR DESCRIPTION
## Summary
- upgrade the protobuf Maven plugin to 0.7.3 so the includeDependencies flag is honored
- bind proto compilation to the generate-sources phase and clean the output directories to avoid conflicting stubs on macOS
- keep gRPC stub generation configuration while preventing dependency proto scanning

## Testing
- mvn -U clean generate-sources -DskipTests compile *(fails: Maven Central returns 403 in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de53e69fd08331b509cbb423b9c235