### PR TITLE
Adjust protobuf plugin version for Maven Central availability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <plugin>
       <groupId>org.xolstice.maven.plugins</groupId>
       <artifactId>protobuf-maven-plugin</artifactId>
-      <version>0.7.3</version>
+      <version>0.6.1</version>
       <configuration>
         <protocArtifact>
           com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}


### PR DESCRIPTION
## Summary
- downgrade protobuf-maven-plugin to a version that remains hosted on Maven Central to restore protobuf code generation builds on macOS

## Testing
- `./mvnw -U clean generate-sources -DskipTests compile` *(fails: Maven wrapper cannot download Maven distribution in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de57e034788331a7328aff3de1f165