### PR TITLE
Avoid duplicate protobuf generation during compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,15 +166,16 @@
       <executions>
         <execution>
           <id>generate-proto-sources</id>
-          <phase>generate-sources</phase>
+          <!--
+            绑定到 compile 阶段，避免在执行 `generate-sources` 和 `compile` 时重复触发，
+            从而规避 macOS 上临时目录无法清理导致的构建失败。
+          -->
+          <phase>compile</phase>
           <goals>
             <goal>compile</goal>         <!-- 生成 protobuf Java -->
             <goal>compile-custom</goal>  <!-- 生成 gRPC stub -->
           </goals>
           <configuration>
-            <!-- 只编译工程内的 proto，避免重复扫描依赖 -->
-            <includeDependencies>false</includeDependencies>
-            <cleanOutputDirectories>true</cleanOutputDirectories>
             <pluginId>grpc-java</pluginId>
             <pluginArtifact>
               io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}


### PR DESCRIPTION
## Summary
- bind the protobuf Maven plugin execution to the compile phase to avoid duplicate runs when `generate-sources` and `compile` are executed together
- drop unsupported clean/include settings from the execution block so the build no longer emits warnings

## Testing
- not run (network-restricted environment)


------
https://chatgpt.com/codex/tasks/task_e_68de62b861588331802f2a9273d60f3b