### PR TITLE
feat: add enterprise profile management apis

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -103,6 +103,7 @@ CREATE TRIGGER set_company_profiles_updated_at
 CREATE TABLE IF NOT EXISTS public.company_contacts (
     contact_id          uuid PRIMARY KEY,
     company_id          uuid        NOT NULL REFERENCES public.company_profiles (company_id) ON DELETE CASCADE,
+    user_account_id     uuid        REFERENCES public.user_accounts (user_id) ON DELETE SET NULL,
     contact_name        varchar(128) NOT NULL,
     contact_email       varchar(255) NOT NULL,
     phone_country_code  varchar(8)   NOT NULL,
@@ -116,6 +117,9 @@ CREATE TABLE IF NOT EXISTS public.company_contacts (
 
 CREATE INDEX IF NOT EXISTS company_contacts_company_id_idx
     ON public.company_contacts (company_id);
+
+CREATE INDEX IF NOT EXISTS company_contacts_user_account_id_idx
+    ON public.company_contacts (user_account_id);
 
 DROP TRIGGER IF EXISTS set_company_contacts_updated_at
     ON public.company_contacts;

--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -118,6 +118,59 @@ All requests/响应均为 JSON，所有字段都带有后端校验（邮箱格�
 ### 前端流程建议
 1. **注册**：发送 purpose=`REGISTER` 的验证码 → 输入验证码连同邮箱、密码一起提交注册 → 保存返回的 `userId` 与令牌。
 2. **忘记密码**：发送 purpose=`RESET_PASSWORD` 的验证码 → 用户填写验证码与新密码 → 调用重置接口 → 引导回登录页重新登录。
+
+## 企业资料维护（企业端）
+
+企业端资料页分左右两部分：左侧展示岗位卡/企业概况，右侧允许编辑企业资料及 HR 列表。以下接口均在完成四步引导后可用，由
+`CompanyProfileController` 暴露。所有请求均接受可选 `Accept-Language` 头部（`zh`/`en`/`jp`），用于返回国家、城市与区号的本地化展示。【F:src/main/java/com/example/grpcdemo/controller/CompanyProfileController.java†L18-L74】【F:src/main/java/com/example/grpcdemo/service/CompanyProfileService.java†L37-L364】
+
+### 1. 查询企业资料
+- **Endpoint**：`GET /api/enterprise/profile?userId={ownerUserId}`
+- **Response** (`CompanyProfileResponse`):
+  - `companyId` —— 企业 ID。
+  - `company` —— 与引导阶段相同的企业信息字段（含 `companyName`、`countryDisplayName`、`recruitingPositions` 等）。
+  - `hrContacts` —— HR 列表，字段包含 `contactId`、`contactName`、`contactEmail`、`phoneCountryCode`、`phoneNumber`、`position`、`department`、`primary`、`userAccountId`。
+
+### 2. 更新企业信息
+- **Endpoint**：`PUT /api/enterprise/profile/company`
+- **Request body** (`CompanyInfoUpdateRequest`):
+  - `userId`（必填）—— 企业所有者账号 ID。
+  - `companyName`、`companyShortName`、`socialCreditCode`、`country`、`city`、`employeeScale`、`annualHiringPlan`、`industry`、`website`、`description`、`detailedAddress`、`recruitingPositions[]` 等字段与四步引导一致。
+- **Response**：更新后的 `CompanyProfileResponse`。
+- **说明**：`recruitingPositions` 会整表覆盖（最多 50 条，自动去重、去空）。
+
+### 3. 新增 HR 账号
+- **Endpoint**：`POST /api/enterprise/profile/hr`
+- **Request body** (`CreateHrRequest`):
+  - `userId`（必填）—— 企业所有者账号 ID。
+  - `contactName`、`contactEmail`、`phoneCountryCode`、`phoneNumber`（必填）。
+  - `position`、`department`、`primary`（可选）。
+  - `password`（可选，8~64 位）。若不传则后端自动生成一组强密码。
+- **Response** (`HrContactResponse`):
+  - `contact` —— 新增后的 HR 资料（含 `userAccountId`）。
+  - `password` —— 新账号的明文密码（只返回一次，前端需提示用户妥善保存）。
+- **行为说明**：会自动创建 `user_accounts` 登录记录，角色固定为 `company`，状态为 `ACTIVE`。若 `primary=true`，其余联系人会被取消主联系人标记。
+
+### 4. 更新 HR 资料
+- **Endpoint**：`PUT /api/enterprise/profile/hr/{contactId}`
+- **Request body** (`HrContactUpdateRequest`):
+  - `userId`（必填）—— 企业所有者账号 ID。
+  - 其余字段与创建时相同，额外支持 `newPassword`（可选）。
+- **Response** (`HrContactResponse`):
+  - `contact` —— 更新后的联系人信息。
+  - `password` —— 若提供 `newPassword` 则原样回传，便于前端提示用户密码已重置；否则为 `null`。
+- **行为说明**：若联系人已绑定 `userAccountId`，修改邮箱或密码会同步更新登录账号；若此前未绑定且提供了 `newPassword`，系统会自动创建新账号并绑定。
+
+### 5. 获取国际电话区号
+- **Endpoint**：`GET /api/enterprise/profile/calling-codes`
+- **Response**：数组元素为 `CallingCodeDto`：`countryCode`（ISO 3166-1）、`countryName`（按 `Accept-Language` 本地化）、`callingCode`（如 `+86`）。
+- **实现**：后端基于 libphonenumber 提供的元数据生成完整列表，可直接渲染到前端下拉框中。
+
+### 6. 生成强密码
+- **Endpoint**：`GET /api/enterprise/profile/password/suggestion`
+- **Response** (`PasswordSuggestionResponse`):
+  - `password` —— 长度 12 的随机强密码（至少包含大小写字母、数字、符号各 1 个）。
+- **用途**：前端在“生成密码”按钮点击时调用，配合创建/编辑 HR 流程使用。
 3. **令牌管理**：`accessToken`、`refreshToken` 当前为占位 UUID，后续可替换为正式 JWT。前端应在 Pinia/Vuex 中妥善保存并在需要时附加到后续请求头。
 
 ## Enterprise onboarding（企业注册资料引导）

--- a/docs/supabase-migrations.md
+++ b/docs/supabase-migrations.md
@@ -10,7 +10,7 @@
 |-----------|----|------|
 | `UserAccountEntity` | `public.user_accounts` | 存储注册的登录账号。字段包含登录邮箱 `email`、`password_hash`、`role`、`status`（`ACTIVE/PENDING/LOCKED`）以及最近登录时间 `last_login_at`，邮箱字段全局唯一。 |
 | `CompanyProfileEntity` | `public.company_profiles` | 保存企业引导完成后的主体信息，包括企业规模、所在地等。 |
-| `CompanyContactEntity` | `public.company_contacts` | 保存企业 HR 联系人及其电话、邮箱等信息。 |
+| `CompanyContactEntity` | `public.company_contacts` | 保存企业 HR 联系人及其电话、邮箱等信息，`user_account_id`（可空）用于关联可登录的 HR 账号。 |
 | `InvitationTemplateEntity` | `public.invitation_templates` | 保存企业配置的邀约邮件模版，并通过部分唯一索引保证每个企业只有一个默认模版。 |
 | `VerificationTokenEntity` | `public.verification_tokens` | 保存企业引导流程中发送的验证码，索引覆盖 `(target_user_id, purpose, code, consumed)` 以支撑查询。 |
 | `Job` | `public.jobs` | 表示通过 gRPC job 服务对外暴露的职位信息。 |

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,13 @@
             <version>1.29</version>
         </dependency>
 
+        <!-- International phone metadata -->
+        <dependency>
+            <groupId>com.googlecode.libphonenumber</groupId>
+            <artifactId>libphonenumber</artifactId>
+            <version>8.13.35</version>
+        </dependency>
+
         <!-- JWT generation -->
         <dependency>
             <groupId>com.auth0</groupId>

--- a/src/main/java/com/example/grpcdemo/controller/CompanyProfileController.java
+++ b/src/main/java/com/example/grpcdemo/controller/CompanyProfileController.java
@@ -1,0 +1,70 @@
+package com.example.grpcdemo.controller;
+
+import com.example.grpcdemo.controller.dto.CallingCodeDto;
+import com.example.grpcdemo.controller.dto.CompanyInfoUpdateRequest;
+import com.example.grpcdemo.controller.dto.CompanyProfileResponse;
+import com.example.grpcdemo.controller.dto.CreateHrRequest;
+import com.example.grpcdemo.controller.dto.HrContactResponse;
+import com.example.grpcdemo.controller.dto.HrContactUpdateRequest;
+import com.example.grpcdemo.controller.dto.PasswordSuggestionResponse;
+import com.example.grpcdemo.service.CompanyProfileService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST endpoints used by the enterprise portal to manage company and HR
+ * information after onboarding.
+ */
+@RestController
+@RequestMapping("/api/enterprise/profile")
+public class CompanyProfileController {
+
+    private final CompanyProfileService companyProfileService;
+
+    public CompanyProfileController(CompanyProfileService companyProfileService) {
+        this.companyProfileService = companyProfileService;
+    }
+
+    @GetMapping
+    public CompanyProfileResponse getProfile(@RequestParam("userId") String userId,
+                                             @RequestHeader(value = "Accept-Language", required = false) String language) {
+        return companyProfileService.getProfile(userId, language);
+    }
+
+    @PutMapping("/company")
+    public CompanyProfileResponse updateCompany(@Valid @RequestBody CompanyInfoUpdateRequest request,
+                                                @RequestHeader(value = "Accept-Language", required = false) String language) {
+        return companyProfileService.updateCompanyInfo(request, language);
+    }
+
+    @PostMapping("/hr")
+    public HrContactResponse createContact(@Valid @RequestBody CreateHrRequest request) {
+        return companyProfileService.createContact(request);
+    }
+
+    @PutMapping("/hr/{contactId}")
+    public HrContactResponse updateContact(@PathVariable("contactId") String contactId,
+                                           @Valid @RequestBody HrContactUpdateRequest request) {
+        return companyProfileService.updateContact(contactId, request);
+    }
+
+    @GetMapping("/calling-codes")
+    public List<CallingCodeDto> listCallingCodes(@RequestHeader(value = "Accept-Language", required = false) String language) {
+        return companyProfileService.listCallingCodes(language);
+    }
+
+    @GetMapping("/password/suggestion")
+    public PasswordSuggestionResponse suggestPassword() {
+        return companyProfileService.generatePassword();
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/CallingCodeDto.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/CallingCodeDto.java
@@ -1,0 +1,44 @@
+package com.example.grpcdemo.controller.dto;
+
+/**
+ * DTO exposing international calling code options.
+ */
+public class CallingCodeDto {
+
+    private String countryCode;
+    private String countryName;
+    private String callingCode;
+
+    public CallingCodeDto() {
+    }
+
+    public CallingCodeDto(String countryCode, String countryName, String callingCode) {
+        this.countryCode = countryCode;
+        this.countryName = countryName;
+        this.callingCode = callingCode;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public String getCountryName() {
+        return countryName;
+    }
+
+    public void setCountryName(String countryName) {
+        this.countryName = countryName;
+    }
+
+    public String getCallingCode() {
+        return callingCode;
+    }
+
+    public void setCallingCode(String callingCode) {
+        this.callingCode = callingCode;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/CompanyInfoUpdateRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/CompanyInfoUpdateRequest.java
@@ -1,0 +1,161 @@
+package com.example.grpcdemo.controller.dto;
+
+import com.example.grpcdemo.onboarding.AnnualHiringPlan;
+import com.example.grpcdemo.onboarding.EmployeeScale;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+/**
+ * Payload used when an enterprise admin updates the company level information
+ * from the profile page.
+ */
+public class CompanyInfoUpdateRequest {
+
+    @NotBlank
+    private String userId;
+
+    @NotBlank
+    private String companyName;
+
+    private String companyShortName;
+
+    private String socialCreditCode;
+
+    @NotBlank
+    private String country;
+
+    @NotBlank
+    private String city;
+
+    @NotNull
+    private EmployeeScale employeeScale;
+
+    @NotNull
+    private AnnualHiringPlan annualHiringPlan;
+
+    private String industry;
+
+    private String website;
+
+    private String description;
+
+    private String detailedAddress;
+
+    private List<@NotBlank String> recruitingPositions;
+
+    private String contactEmail;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public String getCompanyShortName() {
+        return companyShortName;
+    }
+
+    public void setCompanyShortName(String companyShortName) {
+        this.companyShortName = companyShortName;
+    }
+
+    public String getSocialCreditCode() {
+        return socialCreditCode;
+    }
+
+    public void setSocialCreditCode(String socialCreditCode) {
+        this.socialCreditCode = socialCreditCode;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public EmployeeScale getEmployeeScale() {
+        return employeeScale;
+    }
+
+    public void setEmployeeScale(EmployeeScale employeeScale) {
+        this.employeeScale = employeeScale;
+    }
+
+    public AnnualHiringPlan getAnnualHiringPlan() {
+        return annualHiringPlan;
+    }
+
+    public void setAnnualHiringPlan(AnnualHiringPlan annualHiringPlan) {
+        this.annualHiringPlan = annualHiringPlan;
+    }
+
+    public String getIndustry() {
+        return industry;
+    }
+
+    public void setIndustry(String industry) {
+        this.industry = industry;
+    }
+
+    public String getWebsite() {
+        return website;
+    }
+
+    public void setWebsite(String website) {
+        this.website = website;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDetailedAddress() {
+        return detailedAddress;
+    }
+
+    public void setDetailedAddress(String detailedAddress) {
+        this.detailedAddress = detailedAddress;
+    }
+
+    public List<String> getRecruitingPositions() {
+        return recruitingPositions;
+    }
+
+    public void setRecruitingPositions(List<String> recruitingPositions) {
+        this.recruitingPositions = recruitingPositions;
+    }
+
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    public void setContactEmail(String contactEmail) {
+        this.contactEmail = contactEmail;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/CompanyProfileResponse.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/CompanyProfileResponse.java
@@ -1,0 +1,38 @@
+package com.example.grpcdemo.controller.dto;
+
+import java.util.List;
+
+/**
+ * Aggregated view returned to the enterprise portal when displaying the
+ * company overview screen.
+ */
+public class CompanyProfileResponse {
+
+    private String companyId;
+    private EnterpriseCompanyInfoDto company;
+    private List<HrContactDto> hrContacts;
+
+    public String getCompanyId() {
+        return companyId;
+    }
+
+    public void setCompanyId(String companyId) {
+        this.companyId = companyId;
+    }
+
+    public EnterpriseCompanyInfoDto getCompany() {
+        return company;
+    }
+
+    public void setCompany(EnterpriseCompanyInfoDto company) {
+        this.company = company;
+    }
+
+    public List<HrContactDto> getHrContacts() {
+        return hrContacts;
+    }
+
+    public void setHrContacts(List<HrContactDto> hrContacts) {
+        this.hrContacts = hrContacts;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/CreateHrRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/CreateHrRequest.java
@@ -1,0 +1,108 @@
+package com.example.grpcdemo.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request payload for creating a new HR contact with login credentials.
+ */
+public class CreateHrRequest {
+
+    @NotBlank
+    private String userId;
+
+    @NotBlank
+    private String contactName;
+
+    @Email
+    @NotBlank
+    private String contactEmail;
+
+    @NotBlank
+    private String phoneCountryCode;
+
+    @NotBlank
+    private String phoneNumber;
+
+    private String position;
+
+    private String department;
+
+    private Boolean primary;
+
+    @Size(min = 8, max = 64)
+    private String password;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getContactName() {
+        return contactName;
+    }
+
+    public void setContactName(String contactName) {
+        this.contactName = contactName;
+    }
+
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    public void setContactEmail(String contactEmail) {
+        this.contactEmail = contactEmail;
+    }
+
+    public String getPhoneCountryCode() {
+        return phoneCountryCode;
+    }
+
+    public void setPhoneCountryCode(String phoneCountryCode) {
+        this.phoneCountryCode = phoneCountryCode;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getPosition() {
+        return position;
+    }
+
+    public void setPosition(String position) {
+        this.position = position;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public Boolean getPrimary() {
+        return primary;
+    }
+
+    public void setPrimary(Boolean primary) {
+        this.primary = primary;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/HrContactDto.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/HrContactDto.java
@@ -1,0 +1,90 @@
+package com.example.grpcdemo.controller.dto;
+
+/**
+ * Lightweight DTO describing an enterprise HR contact shown on the profile
+ * page.
+ */
+public class HrContactDto {
+
+    private String contactId;
+    private String userAccountId;
+    private String contactName;
+    private String contactEmail;
+    private String phoneCountryCode;
+    private String phoneNumber;
+    private String position;
+    private String department;
+    private boolean primary;
+
+    public String getContactId() {
+        return contactId;
+    }
+
+    public void setContactId(String contactId) {
+        this.contactId = contactId;
+    }
+
+    public String getUserAccountId() {
+        return userAccountId;
+    }
+
+    public void setUserAccountId(String userAccountId) {
+        this.userAccountId = userAccountId;
+    }
+
+    public String getContactName() {
+        return contactName;
+    }
+
+    public void setContactName(String contactName) {
+        this.contactName = contactName;
+    }
+
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    public void setContactEmail(String contactEmail) {
+        this.contactEmail = contactEmail;
+    }
+
+    public String getPhoneCountryCode() {
+        return phoneCountryCode;
+    }
+
+    public void setPhoneCountryCode(String phoneCountryCode) {
+        this.phoneCountryCode = phoneCountryCode;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getPosition() {
+        return position;
+    }
+
+    public void setPosition(String position) {
+        this.position = position;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public boolean isPrimary() {
+        return primary;
+    }
+
+    public void setPrimary(boolean primary) {
+        this.primary = primary;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/HrContactResponse.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/HrContactResponse.java
@@ -1,0 +1,28 @@
+package com.example.grpcdemo.controller.dto;
+
+/**
+ * Response wrapper returned after creating or updating an HR contact. It
+ * optionally surfaces a freshly generated password so the UI can display it
+ * once.
+ */
+public class HrContactResponse {
+
+    private HrContactDto contact;
+    private String password;
+
+    public HrContactDto getContact() {
+        return contact;
+    }
+
+    public void setContact(HrContactDto contact) {
+        this.contact = contact;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/HrContactUpdateRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/HrContactUpdateRequest.java
@@ -1,0 +1,106 @@
+package com.example.grpcdemo.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request payload for updating an existing HR contact.
+ */
+public class HrContactUpdateRequest {
+
+    @NotBlank
+    private String userId;
+
+    @NotBlank
+    private String contactName;
+
+    @Email
+    @NotBlank
+    private String contactEmail;
+
+    @NotBlank
+    private String phoneCountryCode;
+
+    @NotBlank
+    private String phoneNumber;
+
+    private String position;
+
+    private String department;
+
+    private Boolean primary;
+
+    private String newPassword;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getContactName() {
+        return contactName;
+    }
+
+    public void setContactName(String contactName) {
+        this.contactName = contactName;
+    }
+
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    public void setContactEmail(String contactEmail) {
+        this.contactEmail = contactEmail;
+    }
+
+    public String getPhoneCountryCode() {
+        return phoneCountryCode;
+    }
+
+    public void setPhoneCountryCode(String phoneCountryCode) {
+        this.phoneCountryCode = phoneCountryCode;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getPosition() {
+        return position;
+    }
+
+    public void setPosition(String position) {
+        this.position = position;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public Boolean getPrimary() {
+        return primary;
+    }
+
+    public void setPrimary(Boolean primary) {
+        this.primary = primary;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/PasswordSuggestionResponse.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/PasswordSuggestionResponse.java
@@ -1,0 +1,24 @@
+package com.example.grpcdemo.controller.dto;
+
+/**
+ * Simple wrapper returning a generated strong password.
+ */
+public class PasswordSuggestionResponse {
+
+    private String password;
+
+    public PasswordSuggestionResponse() {
+    }
+
+    public PasswordSuggestionResponse(String password) {
+        this.password = password;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/entity/CompanyContactEntity.java
+++ b/src/main/java/com/example/grpcdemo/entity/CompanyContactEntity.java
@@ -21,6 +21,9 @@ public class CompanyContactEntity {
     @Column(name = "company_id", nullable = false, length = 36)
     private String companyId;
 
+    @Column(name = "user_account_id", length = 36)
+    private String userAccountId;
+
     @Column(name = "contact_name", nullable = false, length = 128)
     private String contactName;
 
@@ -62,6 +65,14 @@ public class CompanyContactEntity {
 
     public void setCompanyId(String companyId) {
         this.companyId = companyId;
+    }
+
+    public String getUserAccountId() {
+        return userAccountId;
+    }
+
+    public void setUserAccountId(String userAccountId) {
+        this.userAccountId = userAccountId;
     }
 
     public String getContactName() {

--- a/src/main/java/com/example/grpcdemo/repository/CompanyContactRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/CompanyContactRepository.java
@@ -3,9 +3,18 @@ package com.example.grpcdemo.repository;
 import com.example.grpcdemo.entity.CompanyContactEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CompanyContactRepository extends JpaRepository<CompanyContactEntity, String> {
 
     Optional<CompanyContactEntity> findFirstByCompanyIdOrderByCreatedAtAsc(String companyId);
+
+    List<CompanyContactEntity> findByCompanyIdOrderByCreatedAtAsc(String companyId);
+
+    Optional<CompanyContactEntity> findByContactIdAndCompanyId(String contactId, String companyId);
+
+    List<CompanyContactEntity> findByCompanyId(String companyId);
+
+    Optional<CompanyContactEntity> findByUserAccountId(String userAccountId);
 }

--- a/src/main/java/com/example/grpcdemo/repository/UserAccountRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/UserAccountRepository.java
@@ -11,4 +11,8 @@ import java.util.Optional;
 public interface UserAccountRepository extends JpaRepository<UserAccountEntity, String> {
 
     Optional<UserAccountEntity> findByEmailAndRole(String email, String role);
+
+    Optional<UserAccountEntity> findByEmailIgnoreCase(String email);
+
+    boolean existsByEmailIgnoreCaseAndUserIdNot(String email, String userId);
 }

--- a/src/main/java/com/example/grpcdemo/service/CompanyProfileService.java
+++ b/src/main/java/com/example/grpcdemo/service/CompanyProfileService.java
@@ -1,0 +1,440 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.controller.dto.CallingCodeDto;
+import com.example.grpcdemo.controller.dto.CompanyInfoUpdateRequest;
+import com.example.grpcdemo.controller.dto.CompanyProfileResponse;
+import com.example.grpcdemo.controller.dto.CreateHrRequest;
+import com.example.grpcdemo.controller.dto.EnterpriseCompanyInfoDto;
+import com.example.grpcdemo.controller.dto.HrContactDto;
+import com.example.grpcdemo.controller.dto.HrContactResponse;
+import com.example.grpcdemo.controller.dto.HrContactUpdateRequest;
+import com.example.grpcdemo.controller.dto.PasswordSuggestionResponse;
+import com.example.grpcdemo.entity.CompanyContactEntity;
+import com.example.grpcdemo.entity.CompanyProfileEntity;
+import com.example.grpcdemo.entity.CompanyRecruitingPositionEntity;
+import com.example.grpcdemo.entity.UserAccountEntity;
+import com.example.grpcdemo.entity.UserAccountStatus;
+import com.example.grpcdemo.location.LocationCatalog;
+import com.example.grpcdemo.repository.CompanyContactRepository;
+import com.example.grpcdemo.repository.CompanyProfileRepository;
+import com.example.grpcdemo.repository.CompanyRecruitingPositionRepository;
+import com.example.grpcdemo.repository.UserAccountRepository;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Service exposing enterprise profile maintenance operations used by the
+ * portal once onboarding has completed.
+ */
+@Service
+public class CompanyProfileService {
+
+    private static final String COMPANY_ROLE = "company";
+    private static final int PASSWORD_LENGTH = 12;
+
+    private static final char[] UPPER = "ABCDEFGHJKLMNPQRSTUVWXYZ".toCharArray();
+    private static final char[] LOWER = "abcdefghijkmnopqrstuvwxyz".toCharArray();
+    private static final char[] DIGITS = "23456789".toCharArray();
+    private static final char[] SYMBOLS = "!@#$%^&*()_-+=[]{}".toCharArray();
+    private static final char[] PASSWORD_POOL;
+
+    static {
+        StringBuilder builder = new StringBuilder();
+        builder.append(UPPER);
+        builder.append(LOWER);
+        builder.append(DIGITS);
+        builder.append(SYMBOLS);
+        PASSWORD_POOL = builder.toString().toCharArray();
+    }
+
+    private final CompanyProfileRepository companyProfileRepository;
+    private final CompanyContactRepository companyContactRepository;
+    private final CompanyRecruitingPositionRepository recruitingPositionRepository;
+    private final UserAccountRepository userAccountRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final LocationCatalog locationCatalog;
+    private final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public CompanyProfileService(CompanyProfileRepository companyProfileRepository,
+                                 CompanyContactRepository companyContactRepository,
+                                 CompanyRecruitingPositionRepository recruitingPositionRepository,
+                                 UserAccountRepository userAccountRepository,
+                                 PasswordEncoder passwordEncoder,
+                                 LocationCatalog locationCatalog) {
+        this.companyProfileRepository = companyProfileRepository;
+        this.companyContactRepository = companyContactRepository;
+        this.recruitingPositionRepository = recruitingPositionRepository;
+        this.userAccountRepository = userAccountRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.locationCatalog = locationCatalog;
+    }
+
+    @Transactional
+    public CompanyProfileResponse updateCompanyInfo(CompanyInfoUpdateRequest request, String preferredLanguage) {
+        CompanyProfileEntity profile = requireProfileByOwner(request.getUserId());
+        Instant now = Instant.now();
+
+        profile.setCompanyName(request.getCompanyName());
+        profile.setCompanyShortName(request.getCompanyShortName());
+        profile.setSocialCreditCode(request.getSocialCreditCode());
+        profile.setCountryCode(normalizeCode(request.getCountry()));
+        profile.setCityCode(normalizeCode(request.getCity()));
+        profile.setEmployeeScale(request.getEmployeeScale());
+        profile.setAnnualHiringPlan(request.getAnnualHiringPlan());
+        profile.setIndustry(trimToNull(request.getIndustry()));
+        profile.setWebsite(trimToNull(request.getWebsite()));
+        profile.setDescription(trimToNull(request.getDescription()));
+        profile.setDetailedAddress(trimToNull(request.getDetailedAddress()));
+        profile.setUpdatedAt(now);
+
+        companyProfileRepository.save(profile);
+        replaceRecruitingPositions(profile.getCompanyId(), request.getRecruitingPositions(), now);
+
+        Locale locale = resolveLocale(preferredLanguage);
+        return buildProfileResponse(profile, locale);
+    }
+
+    @Transactional
+    public HrContactResponse createContact(CreateHrRequest request) {
+        CompanyProfileEntity profile = requireProfileByOwner(request.getUserId());
+
+        ensureEmailAvailable(request.getContactEmail(), null);
+
+        String plainPassword = StringUtils.hasText(request.getPassword())
+                ? request.getPassword()
+                : generateStrongPassword();
+
+        String userId = UUID.randomUUID().toString();
+        UserAccountEntity account = new UserAccountEntity();
+        account.setUserId(userId);
+        account.setEmail(request.getContactEmail());
+        account.setPasswordHash(passwordEncoder.encode(plainPassword));
+        account.setRole(COMPANY_ROLE);
+        account.setStatus(UserAccountStatus.ACTIVE);
+        userAccountRepository.save(account);
+
+        CompanyContactEntity contact = new CompanyContactEntity();
+        contact.setContactId(UUID.randomUUID().toString());
+        contact.setCompanyId(profile.getCompanyId());
+        contact.setUserAccountId(userId);
+        contact.setContactName(request.getContactName());
+        contact.setContactEmail(request.getContactEmail());
+        contact.setPhoneCountryCode(request.getPhoneCountryCode());
+        contact.setPhoneNumber(request.getPhoneNumber());
+        contact.setPosition(trimToNull(request.getPosition()));
+        contact.setDepartment(trimToNull(request.getDepartment()));
+        contact.setPrimaryContact(Boolean.TRUE.equals(request.getPrimary()));
+        contact.setCreatedAt(Instant.now());
+        contact.setUpdatedAt(contact.getCreatedAt());
+
+        companyContactRepository.save(contact);
+        if (contact.isPrimaryContact()) {
+            enforcePrimaryContact(profile.getCompanyId(), contact.getContactId());
+        }
+
+        HrContactResponse response = new HrContactResponse();
+        response.setContact(toDto(contact));
+        response.setPassword(plainPassword);
+        return response;
+    }
+
+    @Transactional
+    public HrContactResponse updateContact(String contactId, HrContactUpdateRequest request) {
+        CompanyProfileEntity profile = requireProfileByOwner(request.getUserId());
+        CompanyContactEntity contact = companyContactRepository
+                .findByContactIdAndCompanyId(contactId, profile.getCompanyId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "未找到指定的 HR 联系人"));
+
+        boolean emailChanged = !contact.getContactEmail().equalsIgnoreCase(request.getContactEmail());
+        if (emailChanged) {
+            ensureEmailAvailable(request.getContactEmail(), contact.getUserAccountId());
+        }
+
+        contact.setContactName(request.getContactName());
+        contact.setContactEmail(request.getContactEmail());
+        contact.setPhoneCountryCode(request.getPhoneCountryCode());
+        contact.setPhoneNumber(request.getPhoneNumber());
+        contact.setPosition(trimToNull(request.getPosition()));
+        contact.setDepartment(trimToNull(request.getDepartment()));
+        if (request.getPrimary() != null) {
+            contact.setPrimaryContact(request.getPrimary());
+        }
+        contact.setUpdatedAt(Instant.now());
+
+        String newPassword = null;
+        if (StringUtils.hasText(contact.getUserAccountId())) {
+            Optional<UserAccountEntity> accountOptional = userAccountRepository.findById(contact.getUserAccountId());
+            UserAccountEntity account = accountOptional.orElse(null);
+            if (account != null) {
+                if (emailChanged) {
+                    account.setEmail(request.getContactEmail());
+                }
+                if (StringUtils.hasText(request.getNewPassword())) {
+                    newPassword = request.getNewPassword();
+                    account.setPasswordHash(passwordEncoder.encode(newPassword));
+                }
+                userAccountRepository.save(account);
+            }
+        } else if (StringUtils.hasText(request.getNewPassword())) {
+            newPassword = request.getNewPassword();
+            UserAccountEntity account = new UserAccountEntity();
+            String newUserId = UUID.randomUUID().toString();
+            account.setUserId(newUserId);
+            account.setEmail(request.getContactEmail());
+            account.setPasswordHash(passwordEncoder.encode(newPassword));
+            account.setRole(COMPANY_ROLE);
+            account.setStatus(UserAccountStatus.ACTIVE);
+            userAccountRepository.save(account);
+            contact.setUserAccountId(newUserId);
+        }
+
+        companyContactRepository.save(contact);
+        if (Boolean.TRUE.equals(request.getPrimary())) {
+            enforcePrimaryContact(profile.getCompanyId(), contact.getContactId());
+        }
+
+        HrContactResponse response = new HrContactResponse();
+        response.setContact(toDto(contact));
+        response.setPassword(newPassword);
+        return response;
+    }
+
+    @Transactional
+    public CompanyProfileResponse getProfile(String userId, String preferredLanguage) {
+        CompanyProfileEntity profile = requireProfileByOwner(userId);
+        Locale locale = resolveLocale(preferredLanguage);
+        return buildProfileResponse(profile, locale);
+    }
+
+    @Transactional
+    public List<CallingCodeDto> listCallingCodes(String preferredLanguage) {
+        Locale locale = resolveLocale(preferredLanguage);
+        Set<String> regions = phoneNumberUtil.getSupportedRegions();
+        List<CallingCodeDto> options = new ArrayList<>(regions.size());
+        for (String region : regions) {
+            int code = phoneNumberUtil.getCountryCodeForRegion(region);
+            if (code <= 0) {
+                continue;
+            }
+            String callingCode = "+" + code;
+            Locale countryLocale = new Locale("", region);
+            String displayName = countryLocale.getDisplayCountry(locale);
+            if (!StringUtils.hasText(displayName)) {
+                displayName = countryLocale.getDisplayCountry(Locale.ENGLISH);
+            }
+            options.add(new CallingCodeDto(region, displayName, callingCode));
+        }
+        options.sort(Comparator.comparing(CallingCodeDto::getCountryName, Comparator.nullsLast(String::compareTo))
+                .thenComparing(CallingCodeDto::getCallingCode));
+        return options;
+    }
+
+    public PasswordSuggestionResponse generatePassword() {
+        return new PasswordSuggestionResponse(generateStrongPassword());
+    }
+
+    private CompanyProfileEntity requireProfileByOwner(String userId) {
+        return companyProfileRepository.findByOwnerUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "未找到企业档案"));
+    }
+
+    private CompanyProfileResponse buildProfileResponse(CompanyProfileEntity profile, Locale locale) {
+        CompanyProfileResponse response = new CompanyProfileResponse();
+        response.setCompanyId(profile.getCompanyId());
+        response.setCompany(toCompanyDto(profile, locale));
+        response.setHrContacts(loadContacts(profile.getCompanyId()));
+        return response;
+    }
+
+    private EnterpriseCompanyInfoDto toCompanyDto(CompanyProfileEntity entity, Locale locale) {
+        EnterpriseCompanyInfoDto dto = new EnterpriseCompanyInfoDto();
+        dto.setCompanyName(entity.getCompanyName());
+        dto.setCompanyShortName(entity.getCompanyShortName());
+        dto.setSocialCreditCode(entity.getSocialCreditCode());
+        dto.setCountry(entity.getCountryCode());
+        dto.setCity(entity.getCityCode());
+        dto.setEmployeeScale(entity.getEmployeeScale());
+        dto.setAnnualHiringPlan(entity.getAnnualHiringPlan());
+        dto.setIndustry(entity.getIndustry());
+        dto.setWebsite(entity.getWebsite());
+        dto.setDescription(entity.getDescription());
+        dto.setDetailedAddress(entity.getDetailedAddress());
+        dto.setRecruitingPositions(loadRecruitingPositions(entity.getCompanyId()));
+        locationCatalog.findCountry(entity.getCountryCode(), locale)
+                .ifPresent(option -> dto.setCountryDisplayName(option.name()));
+        locationCatalog.findCity(entity.getCountryCode(), entity.getCityCode(), locale)
+                .ifPresent(option -> dto.setCityDisplayName(option.name()));
+        return dto;
+    }
+
+    private List<String> loadRecruitingPositions(String companyId) {
+        return recruitingPositionRepository.findByCompanyId(companyId).stream()
+                .map(CompanyRecruitingPositionEntity::getPositionName)
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .collect(Collectors.toList());
+    }
+
+    private List<HrContactDto> loadContacts(String companyId) {
+        return companyContactRepository.findByCompanyIdOrderByCreatedAtAsc(companyId).stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private HrContactDto toDto(CompanyContactEntity entity) {
+        HrContactDto dto = new HrContactDto();
+        dto.setContactId(entity.getContactId());
+        dto.setUserAccountId(entity.getUserAccountId());
+        dto.setContactName(entity.getContactName());
+        dto.setContactEmail(entity.getContactEmail());
+        dto.setPhoneCountryCode(entity.getPhoneCountryCode());
+        dto.setPhoneNumber(entity.getPhoneNumber());
+        dto.setPosition(entity.getPosition());
+        dto.setDepartment(entity.getDepartment());
+        dto.setPrimary(entity.isPrimaryContact());
+        return dto;
+    }
+
+    private void replaceRecruitingPositions(String companyId, List<String> positions, Instant now) {
+        List<String> sanitized = sanitizePositions(positions);
+        List<CompanyRecruitingPositionEntity> existing = recruitingPositionRepository.findByCompanyId(companyId);
+        if (!existing.isEmpty()) {
+            recruitingPositionRepository.deleteAll(existing);
+        }
+        if (!sanitized.isEmpty()) {
+            List<CompanyRecruitingPositionEntity> entities = sanitized.stream()
+                    .map(name -> {
+                        CompanyRecruitingPositionEntity record = new CompanyRecruitingPositionEntity();
+                        record.setPositionId(UUID.randomUUID().toString());
+                        record.setCompanyId(companyId);
+                        record.setPositionName(name);
+                        record.setCreatedAt(now);
+                        record.setUpdatedAt(now);
+                        return record;
+                    })
+                    .toList();
+            recruitingPositionRepository.saveAll(entities);
+        }
+    }
+
+    private List<String> sanitizePositions(List<String> positions) {
+        if (positions == null || positions.isEmpty()) {
+            return List.of();
+        }
+        return positions.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .distinct()
+                .limit(50)
+                .toList();
+    }
+
+    private void enforcePrimaryContact(String companyId, String primaryContactId) {
+        List<CompanyContactEntity> contacts = companyContactRepository.findByCompanyId(companyId);
+        for (CompanyContactEntity entity : contacts) {
+            boolean shouldBePrimary = entity.getContactId().equals(primaryContactId);
+            if (entity.isPrimaryContact() != shouldBePrimary) {
+                entity.setPrimaryContact(shouldBePrimary);
+                entity.setUpdatedAt(Instant.now());
+                companyContactRepository.save(entity);
+            }
+        }
+    }
+
+    private void ensureEmailAvailable(String email, String currentUserId) {
+        Optional<UserAccountEntity> existing = userAccountRepository.findByEmailIgnoreCase(email);
+        if (existing.isPresent()) {
+            if (currentUserId == null || !existing.get().getUserId().equals(currentUserId)) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "邮箱已被占用");
+            }
+        }
+    }
+
+    private String generateStrongPassword() {
+        List<Character> characters = new ArrayList<>(PASSWORD_LENGTH);
+        characters.add(randomChar(UPPER));
+        characters.add(randomChar(LOWER));
+        characters.add(randomChar(DIGITS));
+        characters.add(randomChar(SYMBOLS));
+        while (characters.size() < PASSWORD_LENGTH) {
+            characters.add(randomChar(PASSWORD_POOL));
+        }
+        java.util.Collections.shuffle(characters, secureRandom);
+        StringBuilder builder = new StringBuilder(characters.size());
+        for (Character character : characters) {
+            builder.append(character);
+        }
+        return builder.toString();
+    }
+
+    private char randomChar(char[] candidates) {
+        return candidates[secureRandom.nextInt(candidates.length)];
+    }
+
+    private Locale resolveLocale(String preferredLanguage) {
+        String language = normalizeLanguage(preferredLanguage);
+        if (language == null) {
+            return Locale.SIMPLIFIED_CHINESE;
+        }
+        return switch (language) {
+            case "en" -> Locale.ENGLISH;
+            case "jp" -> Locale.JAPANESE;
+            default -> Locale.SIMPLIFIED_CHINESE;
+        };
+    }
+
+    private String normalizeLanguage(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return null;
+        }
+        String[] segments = raw.toLowerCase(Locale.ROOT).split(",");
+        for (String segment : segments) {
+            String candidate = segment.trim();
+            int semicolon = candidate.indexOf(';');
+            if (semicolon >= 0) {
+                candidate = candidate.substring(0, semicolon).trim();
+            }
+            int dash = candidate.indexOf('-');
+            if (dash >= 0) {
+                candidate = candidate.substring(0, dash);
+            }
+            int underscore = candidate.indexOf('_');
+            if (underscore >= 0) {
+                candidate = candidate.substring(0, underscore);
+            }
+            if (candidate.equals("zh") || candidate.equals("en") || candidate.equals("jp")) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private String normalizeCode(String code) {
+        return code == null ? null : code.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private String trimToNull(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/com/example/grpcdemo/service/EnterpriseOnboardingService.java
+++ b/src/main/java/com/example/grpcdemo/service/EnterpriseOnboardingService.java
@@ -291,7 +291,7 @@ public class EnterpriseOnboardingService {
 
             String companyId = UUID.randomUUID().toString();
             CompanyProfileEntity profile = createCompanyProfileEntity(step1, request.getUserId(), companyId, now);
-            CompanyContactEntity contact = createContactEntity(step2, companyId, now);
+            CompanyContactEntity contact = createContactEntity(step2, companyId, request.getUserId(), now);
             InvitationTemplateEntity template = createTemplateEntity(step3, companyId, now);
             List<CompanyRecruitingPositionEntity> recruitingPositions =
                     createRecruitingPositionEntities(step1.recruitingPositions, companyId, now);
@@ -672,10 +672,11 @@ public class EnterpriseOnboardingService {
         return profile;
     }
 
-    private CompanyContactEntity createContactEntity(Step2Data data, String companyId, Instant now) {
+    private CompanyContactEntity createContactEntity(Step2Data data, String companyId, String userId, Instant now) {
         CompanyContactEntity contact = new CompanyContactEntity();
         contact.setContactId(UUID.randomUUID().toString());
         contact.setCompanyId(companyId);
+        contact.setUserAccountId(userId);
         contact.setContactName(data.contactName);
         contact.setContactEmail(data.contactEmail);
         contact.setPhoneCountryCode(data.phoneCountryCode);

--- a/技术接口文档&数据库基本结构.md
+++ b/技术接口文档&数据库基本结构.md
@@ -67,6 +67,7 @@
       | 字段                 | 类型          | 说明 |
       | `contact_id`         | CHAR(36) (PK) | 联系人 ID |
       | `company_id`         | CHAR(36)      | 关联企业 ID |
+      | `user_account_id`    | CHAR(36)      | 对应登录账号 ID，可空 |
       | `contact_name`       | VARCHAR(128)  | 联系人姓名 |
       | `contact_email`      | VARCHAR(255)  | 联系人邮箱 |
       | `phone_country_code` | VARCHAR(8)    | 区号，例如 `+86` |
@@ -113,7 +114,38 @@
     | 验证码已过期         | 400    | `VERIFICATION_CODE_EXPIRED` | 过期时间早于当前时间 |
     | 已经完成过引导       | 409    | `ONBOARDING_ALREADY_COMPLETED` | 重复提交 |
 
-  # 三,企业端（岗位空）
+  # 三,企业资料维护页面
+   ## 1.功能概述
+     入口：企业端左上角“资料信息”，分为左侧岗位概览与右侧资料编辑区域。
+     - 左栏沿用 `company_profiles` 与 `company_recruiting_positions` 数据，展示企业信息及岗位卡列表。
+     - 右栏支持修改企业主体信息、维护 HR 列表、新增 HR 账号、生成安全密码、下拉选择国际区号。
+     所有接口需要传入企业所有者的 `userId` 用于权限校验，支持 `Accept-Language`（`zh`/`en`/`jp`）返回本地化国家/城市/区号名称。
+
+   ## 2.API 设计
+     | 方法 | URI | 描述 |
+     | `GET` | `/api/enterprise/profile` | 根据 `userId` 返回企业概览与 HR 列表 |
+     | `PUT` | `/api/enterprise/profile/company` | 更新企业主体信息与在招岗位列表 |
+     | `POST` | `/api/enterprise/profile/hr` | 新增 HR（自动创建登录账号，可选自定义密码）|
+     | `PUT` | `/api/enterprise/profile/hr/{contactId}` | 更新既有 HR 信息，可重置密码 |
+     | `GET` | `/api/enterprise/profile/calling-codes` | 返回国家/地区电话区号列表 |
+     | `GET` | `/api/enterprise/profile/password/suggestion` | 生成一组强密码供前端展示 |
+
+   ## 3.请求与返回说明
+     - 企业信息更新 `CompanyInfoUpdateRequest`：字段与引导步骤 1 保持一致，`recruitingPositions[]` 最多 50 项，后端会自动去重、裁剪空白。
+     - HR 创建 `CreateHrRequest`：必填 `contactName`、`contactEmail`、`phoneCountryCode`、`phoneNumber`，`password` 可空（为空时后端生成 12 位强密码并在响应返回一次）。
+     - HR 更新 `HrContactUpdateRequest`：除基础字段外新增 `newPassword`，若填写则同步更新/创建登录账号并在响应 `password` 字段透出。
+     - `CompanyProfileResponse` 返回企业 ID、企业信息快照（含 `countryDisplayName`、`recruitingPositions`）、`hrContacts[]`（含 `userAccountId`、`primary` 标记）。
+     - 区号列表 `CallingCodeDto`：`countryCode`（ISO 3166-1）、`countryName`（按 `Accept-Language` 转换）、`callingCode`（形如 `+81`）。
+
+   ## 4.交互补充
+     - 新建/重置密码会自动使用 BCrypt 加密写入 `user_accounts`，角色固定为 `company`，状态 `ACTIVE`。
+     - `primary=true` 时会自动取消其他联系人主联系人标记。
+     - 区号列表使用 libphonenumber 元数据即时生成，无需额外配置。
+
+   ## 5.数据库设计更新
+     `company_contacts` 表新增字段 `user_account_id UUID REFERENCES public.user_accounts(user_id) ON DELETE SET NULL`，并创建索引 `company_contacts_user_account_id_idx`，用于映射可登录的 HR 账号。
+
+  # 四,企业端（岗位空）
    ## 1.功能概述
       触发条件：企业用户首次登录且岗位列表为空。
       目标：引导用户快速创建首个岗位卡片，支持 PDF 上传解析与字段校正。
@@ -156,7 +188,7 @@
    ## 4.错误码约定？
       比如：PARSE_FAILED 解析失败
   
-  # 四,企业端岗位候选人导入与管理
+  # 五,企业端岗位候选人导入与管理
    ## 1.功能概述
      在企业端岗位详情页支持批量导入候选人简历，自动解析并维护候选人信息、状态、邮件邀约与面试记录。
    ## 2.状态机定义（JobCandidateStatus）
@@ -203,7 +235,7 @@
    ## 5.数据库设计
      candidates表，job_candidates表，candidate_resumes表，notifications表，interviews / interview_records表，具体暂时省略
   
-  # 五,候选人后端功能
+  # 六,候选人后端功能
    ## 1.功能概述
      目标：为候选人提供面试邀请查看、设备检测、在线答题与面试状态管理能力。
    ## 2.API设计


### PR DESCRIPTION
## Summary
- add REST endpoints to fetch/update enterprise profiles, manage HR contacts, list calling codes and generate strong passwords
- persist HR contact-user relationships and sanitize recruiting positions when updating company info
- document the new APIs and schema updates for frontend teams and Supabase migrations

## Testing
- ./mvnw -DskipTests package *(fails: Maven wrapper could not download Maven distribution in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68df6f178f6c833192e2da0678932ef4