### PR TITLE
feat: return job PDF preview html

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -146,6 +146,32 @@ CREATE TRIGGER set_company_recruiting_positions_updated_at
     FOR EACH ROW
     EXECUTE FUNCTION public.set_updated_at();
 
+CREATE TABLE IF NOT EXISTS public.company_job_documents (
+    document_id      uuid PRIMARY KEY,
+    position_id      uuid        NOT NULL REFERENCES public.company_recruiting_positions (position_id) ON DELETE CASCADE,
+    file_name        varchar(255),
+    file_type        varchar(100),
+    file_content     bytea,
+    upload_user_id   uuid,
+    ai_raw_result    text,
+    parsed_title     varchar(255),
+    parsed_location  varchar(255),
+    parsed_publisher varchar(255),
+    confidence       numeric(5, 2),
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS company_job_documents_position_uidx
+    ON public.company_job_documents (position_id);
+
+DROP TRIGGER IF EXISTS set_company_job_documents_updated_at
+    ON public.company_job_documents;
+CREATE TRIGGER set_company_job_documents_updated_at
+    BEFORE UPDATE ON public.company_job_documents
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_updated_at();
+
 CREATE TABLE IF NOT EXISTS public.invitation_templates (
     template_id     uuid PRIMARY KEY,
     company_id      uuid        NOT NULL REFERENCES public.company_profiles (company_id) ON DELETE CASCADE,

--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -204,7 +204,7 @@ All requests/响应均为 JSON，所有字段都带有后端校验（邮箱格�
 - **Response** (`JobDetailResponse`):
   - `card` —— 最新岗位卡片快照。
   - `source` —— 创建来源（目前固定 `AI_IMPORT`）。
-  - `document` —— 解析详情（`JobDocumentResponse`），含原文件名、AI 提取的标题/地点/发布人、置信度、原始 JSON/错误信息。
+  - `document` —— 解析详情（`JobDocumentResponse`），含原文件名、AI 提取的标题/地点/发布人、置信度、原始 JSON/错误信息，以及 `documentHtml` 字段（内嵌 `<iframe>` 字符串，直接放入页面即可预览上传的 PDF）。
 - **失败处理**：
   - 文件为空或读取异常返回 400。
   - AI 解析失败时 `status` 会标记为 `PARSE_FAILED`，`document.aiRawResult` 返回错误信息，前端可提示用户转入手动编辑流程。【F:src/main/java/com/example/grpcdemo/service/CompanyJobService.java†L75-L143】
@@ -212,7 +212,7 @@ All requests/响应均为 JSON，所有字段都带有后端校验（邮箱格�
 
 ### 4. 查看岗位详情
 - **Endpoint**：`GET /api/enterprise/jobs/{positionId}`
-- **Response**：`JobDetailResponse`，结构同上，便于在编辑页面回填解析信息。
+- **Response**：`JobDetailResponse`，结构同上，便于在编辑页面回填解析信息。`document.documentHtml` 会返回一个内嵌 `<iframe>` 的 HTML 字符串，可直接插入岗位描述区域展示原始 PDF。
 
 ### 5. 编辑岗位卡片
 - **Endpoint**：`PATCH /api/enterprise/jobs/{positionId}`

--- a/src/main/java/com/example/grpcdemo/controller/dto/JobDocumentResponse.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/JobDocumentResponse.java
@@ -17,6 +17,7 @@ public class JobDocumentResponse {
     private final String parsedPublisher;
     private final Float confidence;
     private final String aiRawResult;
+    private final String documentHtml;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private final Instant createdAt;
@@ -32,6 +33,7 @@ public class JobDocumentResponse {
                                String parsedPublisher,
                                Float confidence,
                                String aiRawResult,
+                               String documentHtml,
                                Instant createdAt,
                                Instant updatedAt) {
         this.documentId = documentId;
@@ -42,6 +44,7 @@ public class JobDocumentResponse {
         this.parsedPublisher = parsedPublisher;
         this.confidence = confidence;
         this.aiRawResult = aiRawResult;
+        this.documentHtml = documentHtml;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -76,6 +79,10 @@ public class JobDocumentResponse {
 
     public String getAiRawResult() {
         return aiRawResult;
+    }
+
+    public String getDocumentHtml() {
+        return documentHtml;
     }
 
     public Instant getCreatedAt() {

--- a/src/main/java/com/example/grpcdemo/entity/CompanyJobDocumentEntity.java
+++ b/src/main/java/com/example/grpcdemo/entity/CompanyJobDocumentEntity.java
@@ -28,6 +28,10 @@ public class CompanyJobDocumentEntity {
     @Column(name = "file_type", length = 100)
     private String fileType;
 
+    @Lob
+    @Column(name = "file_content")
+    private byte[] fileContent;
+
     @Column(name = "upload_user_id", length = 36)
     private String uploadUserId;
 
@@ -83,6 +87,14 @@ public class CompanyJobDocumentEntity {
 
     public void setFileType(String fileType) {
         this.fileType = fileType;
+    }
+
+    public byte[] getFileContent() {
+        return fileContent;
+    }
+
+    public void setFileContent(byte[] fileContent) {
+        this.fileContent = fileContent;
     }
 
     public String getUploadUserId() {

--- a/src/main/java/com/example/grpcdemo/service/CompanyJobService.java
+++ b/src/main/java/com/example/grpcdemo/service/CompanyJobService.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.Base64;
 
 /**
  * 与企业岗位卡片交互的领域服务。
@@ -131,6 +132,7 @@ public class CompanyJobService {
         document.setPositionId(positionId);
         document.setFileName(fileName);
         document.setFileType(contentType);
+        document.setFileContent(content);
         document.setUploadUserId(uploaderUserId);
         document.setCreatedAt(now);
         document.setUpdatedAt(now);
@@ -223,11 +225,25 @@ public class CompanyJobService {
                     document.getParsedPublisher(),
                     document.getConfidence(),
                     document.getAiRawResult(),
+                    buildDocumentHtml(document),
                     document.getCreatedAt(),
                     document.getUpdatedAt());
         }
         JobCardResponse card = toCard(entity);
         return new JobDetailResponse(card, entity.getSource(), documentResponse);
+    }
+
+    private String buildDocumentHtml(CompanyJobDocumentEntity document) {
+        byte[] content = document.getFileContent();
+        if (content == null || content.length == 0) {
+            return null;
+        }
+        String mimeType = StringUtils.hasText(document.getFileType())
+                ? document.getFileType()
+                : "application/pdf";
+        String base64 = Base64.getEncoder().encodeToString(content);
+        return "<iframe src=\"data:" + mimeType + ";base64," + base64
+                + "\" style=\"width:100%;height:100%;border:none;\"></iframe>";
     }
 
     private String resolveCompanyId(String companyId, String userId) {

--- a/技术接口文档&数据库基本结构.md
+++ b/技术接口文档&数据库基本结构.md
@@ -93,6 +93,7 @@
       | `position_id`      | CHAR(36)       | 关联岗位 ID |
       | `file_name`        | VARCHAR(255)   | 上传时的原始文件名 |
       | `file_type`        | VARCHAR(100)   | MIME 类型，例如 `application/pdf` |
+      | `file_content`     | BYTEA          | PDF 二进制内容，用于岗位详情页还原原始文档 |
       | `upload_user_id`   | CHAR(36)       | 上传者用户 ID |
       | `ai_raw_result`    | TEXT           | AI 原始返回 JSON 或错误信息 |
       | `parsed_title`     | VARCHAR(255)   | AI 解析出的岗位名称，可空 |
@@ -179,7 +180,8 @@
 
    ## 3.数据与状态
       - 岗位数据落在 `company_recruiting_positions` 表，新增字段 `position_location`、`publisher_nickname`、`position_status`、`position_source`、`document_id` 与 UI 展示保持一致。
-      - 每次导入都会写入一条 `company_job_documents` 记录，保存上传文件元数据与 AI 原始返回，便于排查解析质量。
+      - 每次导入都会写入一条 `company_job_documents` 记录，保存上传文件元数据、PDF 二进制内容与 AI 原始返回，便于排查解析质量并支撑岗位详情页预览原始文档。
+      - 岗位详情接口 `JobDetailResponse.document.documentHtml` 返回 `<iframe>` HTML 字符串，前端可直接插入岗位描述区域展示 HR 上传的 PDF。
       - 岗位状态枚举：
         - `DRAFT_PARSED`：AI 已解析完成，待 HR 校验。
         - `READY`：HR 已确认字段，等待发布。


### PR DESCRIPTION
## Summary
- persist the uploaded PDF binary alongside job document metadata so the detail API can expose an iframe-ready preview
- surface the new `documentHtml` string in `JobDocumentResponse` and describe it in the enterprise job integration docs
- expand the database schema documentation to include the PDF content column and explain the preview behaviour for front-end teams

## Testing
- ./mvnw -q test *(fails: unable to download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc868b9b88331af6fb0e3e7815021