### PR TITLE
feat: add resume import and candidate management APIs

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -198,6 +198,56 @@ CREATE UNIQUE INDEX IF NOT EXISTS invitation_templates_company_default_uidx
     ON public.invitation_templates (company_id)
     WHERE is_default;
 
+CREATE TABLE IF NOT EXISTS public.job_candidates (
+    job_candidate_id uuid PRIMARY KEY,
+    position_id      uuid        NOT NULL REFERENCES public.company_recruiting_positions (position_id) ON DELETE CASCADE,
+    candidate_name   varchar(255),
+    candidate_email  varchar(255),
+    candidate_phone  varchar(64),
+    invite_status    varchar(32)  NOT NULL,
+    interview_status varchar(32)  NOT NULL,
+    resume_id        uuid,
+    uploader_user_id uuid,
+    created_at       timestamptz  NOT NULL DEFAULT now(),
+    updated_at       timestamptz  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS job_candidates_position_id_idx
+    ON public.job_candidates (position_id);
+
+DROP TRIGGER IF EXISTS set_job_candidates_updated_at
+    ON public.job_candidates;
+CREATE TRIGGER set_job_candidates_updated_at
+    BEFORE UPDATE ON public.job_candidates
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE IF NOT EXISTS public.job_candidate_resumes (
+    resume_id       uuid PRIMARY KEY,
+    job_candidate_id uuid       NOT NULL REFERENCES public.job_candidates (job_candidate_id) ON DELETE CASCADE,
+    file_name       varchar(255),
+    file_type       varchar(100),
+    file_content    bytea,
+    parsed_name     varchar(255),
+    parsed_email    varchar(255),
+    parsed_phone    varchar(64),
+    parsed_html     text,
+    confidence      numeric(5, 2),
+    ai_raw_result   text,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS job_candidate_resumes_candidate_uidx
+    ON public.job_candidate_resumes (job_candidate_id);
+
+DROP TRIGGER IF EXISTS set_job_candidate_resumes_updated_at
+    ON public.job_candidate_resumes;
+CREATE TRIGGER set_job_candidate_resumes_updated_at
+    BEFORE UPDATE ON public.job_candidate_resumes
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_updated_at();
+
 CREATE TABLE IF NOT EXISTS public.enterprise_onboarding_sessions (
     user_id       uuid PRIMARY KEY,
     current_step  integer      NOT NULL,

--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -224,6 +224,23 @@ All requests/响应均为 JSON，所有字段都带有后端校验（邮箱格�
 - **Response**：更新后的 `JobDetailResponse`。若仅传空值、不造成任何变化，后端会返回当前数据库快照。
 - **行为说明**：字段发生变化时会自动把岗位状态更新为 `READY` 并刷新 `updatedAt`，岗位卡列表可直接使用响应中的 `card` 回填 UI。【F:src/main/java/com/example/grpcdemo/service/CompanyJobService.java†L145-L205】
 
+### 6. 岗位候选人批量导入与管理
+- **批量上传**：`POST /api/enterprise/jobs/{positionId}/candidates/import`
+  - `multipart/form-data`，参数：`uploaderUserId`（必填）+ `files[]`（必填，支持多份简历）。
+  - 后端逐份调用 AI 简历解析服务（生产：`RestResumeParser` → `POST /resumes:parse`，测试：`StubResumeParser` 直接从文件名生成占位数据）。
+  - 返回 `JobCandidateImportResponse`，包含导入成功的候选人条目及当前岗位的状态统计。
+  - 若未解析出邮箱，`inviteStatus=EMAIL_MISSING`，前端需提示补录；解析失败时 `importedCandidates[].resumeAvailable=true` 但 `summary.emailMissing` 会计数。【F:src/main/java/com/example/grpcdemo/controller/CompanyJobCandidateController.java†L20-L40】【F:src/main/java/com/example/grpcdemo/service/CompanyJobCandidateService.java†L60-L137】【F:src/main/java/com/example/grpcdemo/service/RestResumeParser.java†L16-L71】【F:src/main/java/com/example/grpcdemo/service/StubResumeParser.java†L13-L29】
+- **岗位内检索**：`GET /api/enterprise/jobs/{positionId}/candidates?keyword=xxx`
+  - `keyword` 同时匹配姓名/邮箱/电话，若不传则返回按导入时间倒序的全量列表。
+  - 响应 `JobCandidateListResponse`，附带 `summary`（待邀约、已邀约、邮箱缺失、面试状态等聚合）。【F:src/main/java/com/example/grpcdemo/service/CompanyJobCandidateService.java†L139-L166】
+- **候选人详情**：`GET /api/enterprise/job-candidates/{jobCandidateId}/resume`
+  - 返回 `JobCandidateResumeResponse`，包含基础信息、AI 解析出的 HTML 片段以及原始简历的 `<iframe>` HTML，可直接嵌入预览区。【F:src/main/java/com/example/grpcdemo/service/CompanyJobCandidateService.java†L168-L202】【F:src/main/java/com/example/grpcdemo/controller/JobCandidateController.java†L24-L28】
+- **人工补录/更新**：`PATCH /api/enterprise/job-candidates/{jobCandidateId}`
+  - 支持修改姓名、邮箱、电话、邀约状态、面试状态，以及可编辑的 `resumeHtml`。邮箱被清空会自动回退到 `EMAIL_MISSING`，补齐邮箱后默认切换为 `INVITE_PENDING`。【F:src/main/java/com/example/grpcdemo/service/CompanyJobCandidateService.java†L204-L236】
+- **发送邀约邮件**：`POST /api/enterprise/job-candidates/{jobCandidateId}/invite`
+  - 请求体可选 `templateId`（覆盖默认模版）与 `cc[]`。后端读取企业默认邀约模版，使用 `JavaMailSender` 发送成功后把状态更新为 `INVITE_SENT`，发送失败会回写 `INVITE_FAILED` 并返回 500。【F:src/main/java/com/example/grpcdemo/service/CompanyJobCandidateService.java†L238-L275】【F:src/main/java/com/example/grpcdemo/controller/JobCandidateController.java†L30-L39】
+- **岗位搜索增强**：岗位列表接口新增 `keyword` 参数，可在后端按岗位名称模糊查询，未命中时仍返回原本的倒序列表，供“搜索岗位名称”输入框复用。【F:src/main/java/com/example/grpcdemo/controller/CompanyJobController.java†L38-L43】【F:src/main/java/com/example/grpcdemo/service/CompanyJobService.java†L59-L73】
+
 ## Enterprise onboarding（企业注册资料引导）
 
 企业端完成邮箱注册并首次登录后，需要在浏览器里按四个步骤补全企业资料。所有接口都由

--- a/src/main/java/com/example/grpcdemo/controller/CompanyJobCandidateController.java
+++ b/src/main/java/com/example/grpcdemo/controller/CompanyJobCandidateController.java
@@ -1,0 +1,48 @@
+package com.example.grpcdemo.controller;
+
+import com.example.grpcdemo.controller.dto.JobCandidateImportResponse;
+import com.example.grpcdemo.controller.dto.JobCandidateListResponse;
+import com.example.grpcdemo.service.CompanyJobCandidateService;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 岗位候选人导入与查询接口。
+ */
+@RestController
+@RequestMapping("/api/enterprise/jobs")
+@Validated
+public class CompanyJobCandidateController {
+
+    private final CompanyJobCandidateService candidateService;
+
+    public CompanyJobCandidateController(CompanyJobCandidateService candidateService) {
+        this.candidateService = candidateService;
+    }
+
+    @PostMapping(value = "/{positionId}/candidates/import", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public JobCandidateImportResponse importCandidates(@PathVariable("positionId") String positionId,
+                                                       @RequestParam("uploaderUserId") @NotBlank String uploaderUserId,
+                                                       @RequestPart("files") MultipartFile[] files) {
+        List<MultipartFile> fileList = files != null ? Arrays.asList(files) : List.of();
+        return candidateService.importCandidates(positionId, uploaderUserId, fileList);
+    }
+
+    @GetMapping("/{positionId}/candidates")
+    public JobCandidateListResponse list(@PathVariable("positionId") String positionId,
+                                         @RequestParam(value = "keyword", required = false) String keyword) {
+        return candidateService.listCandidates(positionId, keyword);
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/CompanyJobController.java
+++ b/src/main/java/com/example/grpcdemo/controller/CompanyJobController.java
@@ -44,8 +44,9 @@ public class CompanyJobController {
 
     @GetMapping
     public List<JobCardResponse> list(@RequestParam(value = "companyId", required = false) String companyId,
-                                      @RequestParam(value = "userId", required = false) String userId) {
-        return companyJobService.listCards(companyId, userId);
+                                      @RequestParam(value = "userId", required = false) String userId,
+                                      @RequestParam(value = "keyword", required = false) String keyword) {
+        return companyJobService.listCards(companyId, userId, keyword);
     }
 
     @GetMapping("/{positionId}")

--- a/src/main/java/com/example/grpcdemo/controller/JobCandidateController.java
+++ b/src/main/java/com/example/grpcdemo/controller/JobCandidateController.java
@@ -1,0 +1,46 @@
+package com.example.grpcdemo.controller;
+
+import com.example.grpcdemo.controller.dto.JobCandidateInviteRequest;
+import com.example.grpcdemo.controller.dto.JobCandidateItemResponse;
+import com.example.grpcdemo.controller.dto.JobCandidateResumeResponse;
+import com.example.grpcdemo.controller.dto.JobCandidateUpdateRequest;
+import com.example.grpcdemo.service.CompanyJobCandidateService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 候选人详情与操作接口。
+ */
+@RestController
+@RequestMapping("/api/enterprise/job-candidates")
+public class JobCandidateController {
+
+    private final CompanyJobCandidateService candidateService;
+
+    public JobCandidateController(CompanyJobCandidateService candidateService) {
+        this.candidateService = candidateService;
+    }
+
+    @GetMapping("/{jobCandidateId}/resume")
+    public JobCandidateResumeResponse resume(@PathVariable("jobCandidateId") String jobCandidateId) {
+        return candidateService.getResume(jobCandidateId);
+    }
+
+    @PatchMapping("/{jobCandidateId}")
+    public JobCandidateItemResponse update(@PathVariable("jobCandidateId") String jobCandidateId,
+                                           @Valid @RequestBody JobCandidateUpdateRequest request) {
+        return candidateService.updateCandidate(jobCandidateId, request);
+    }
+
+    @PostMapping("/{jobCandidateId}/invite")
+    public JobCandidateItemResponse sendInvite(@PathVariable("jobCandidateId") String jobCandidateId,
+                                               @Valid @RequestBody(required = false) JobCandidateInviteRequest request) {
+        return candidateService.sendInvite(jobCandidateId, request);
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateImportResponse.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateImportResponse.java
@@ -1,0 +1,29 @@
+package com.example.grpcdemo.controller.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 候选人导入后的响应。
+ */
+public class JobCandidateImportResponse {
+
+    private List<JobCandidateItemResponse> importedCandidates = new ArrayList<>();
+    private JobCandidateStatusSummary summary;
+
+    public List<JobCandidateItemResponse> getImportedCandidates() {
+        return importedCandidates;
+    }
+
+    public void setImportedCandidates(List<JobCandidateItemResponse> importedCandidates) {
+        this.importedCandidates = importedCandidates;
+    }
+
+    public JobCandidateStatusSummary getSummary() {
+        return summary;
+    }
+
+    public void setSummary(JobCandidateStatusSummary summary) {
+        this.summary = summary;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateInviteRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateInviteRequest.java
@@ -1,0 +1,32 @@
+package com.example.grpcdemo.controller.dto;
+
+import jakarta.validation.constraints.Email;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 发送邀约请求。
+ */
+public class JobCandidateInviteRequest {
+
+    private String templateId;
+
+    private List<@Email(message = "抄送邮箱格式不正确") String> cc = new ArrayList<>();
+
+    public String getTemplateId() {
+        return templateId;
+    }
+
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
+    }
+
+    public List<String> getCc() {
+        return cc;
+    }
+
+    public void setCc(List<String> cc) {
+        this.cc = cc;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateItemResponse.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateItemResponse.java
@@ -1,0 +1,139 @@
+package com.example.grpcdemo.controller.dto;
+
+import com.example.grpcdemo.entity.JobCandidateInterviewStatus;
+import com.example.grpcdemo.entity.JobCandidateInviteStatus;
+
+import java.time.Instant;
+
+/**
+ * 候选人列表展示项。
+ */
+public class JobCandidateItemResponse {
+
+    private String jobCandidateId;
+    private String positionId;
+    private String name;
+    private String email;
+    private String phone;
+    private JobCandidateInviteStatus inviteStatus;
+    private JobCandidateInterviewStatus interviewStatus;
+    private boolean emailMissing;
+    private boolean resumeAvailable;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    public JobCandidateItemResponse() {
+    }
+
+    public JobCandidateItemResponse(String jobCandidateId,
+                                    String positionId,
+                                    String name,
+                                    String email,
+                                    String phone,
+                                    JobCandidateInviteStatus inviteStatus,
+                                    JobCandidateInterviewStatus interviewStatus,
+                                    boolean emailMissing,
+                                    boolean resumeAvailable,
+                                    Instant createdAt,
+                                    Instant updatedAt) {
+        this.jobCandidateId = jobCandidateId;
+        this.positionId = positionId;
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+        this.inviteStatus = inviteStatus;
+        this.interviewStatus = interviewStatus;
+        this.emailMissing = emailMissing;
+        this.resumeAvailable = resumeAvailable;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public String getJobCandidateId() {
+        return jobCandidateId;
+    }
+
+    public void setJobCandidateId(String jobCandidateId) {
+        this.jobCandidateId = jobCandidateId;
+    }
+
+    public String getPositionId() {
+        return positionId;
+    }
+
+    public void setPositionId(String positionId) {
+        this.positionId = positionId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public JobCandidateInviteStatus getInviteStatus() {
+        return inviteStatus;
+    }
+
+    public void setInviteStatus(JobCandidateInviteStatus inviteStatus) {
+        this.inviteStatus = inviteStatus;
+    }
+
+    public JobCandidateInterviewStatus getInterviewStatus() {
+        return interviewStatus;
+    }
+
+    public void setInterviewStatus(JobCandidateInterviewStatus interviewStatus) {
+        this.interviewStatus = interviewStatus;
+    }
+
+    public boolean isEmailMissing() {
+        return emailMissing;
+    }
+
+    public void setEmailMissing(boolean emailMissing) {
+        this.emailMissing = emailMissing;
+    }
+
+    public boolean isResumeAvailable() {
+        return resumeAvailable;
+    }
+
+    public void setResumeAvailable(boolean resumeAvailable) {
+        this.resumeAvailable = resumeAvailable;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateListResponse.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateListResponse.java
@@ -1,0 +1,29 @@
+package com.example.grpcdemo.controller.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 岗位候选人列表响应。
+ */
+public class JobCandidateListResponse {
+
+    private List<JobCandidateItemResponse> candidates = new ArrayList<>();
+    private JobCandidateStatusSummary summary;
+
+    public List<JobCandidateItemResponse> getCandidates() {
+        return candidates;
+    }
+
+    public void setCandidates(List<JobCandidateItemResponse> candidates) {
+        this.candidates = candidates;
+    }
+
+    public JobCandidateStatusSummary getSummary() {
+        return summary;
+    }
+
+    public void setSummary(JobCandidateStatusSummary summary) {
+        this.summary = summary;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateResumeResponse.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateResumeResponse.java
@@ -1,0 +1,130 @@
+package com.example.grpcdemo.controller.dto;
+
+import com.example.grpcdemo.entity.JobCandidateInterviewStatus;
+import com.example.grpcdemo.entity.JobCandidateInviteStatus;
+
+import java.time.Instant;
+
+/**
+ * 候选人简历详情响应。
+ */
+public class JobCandidateResumeResponse {
+
+    private String jobCandidateId;
+    private String positionId;
+    private String name;
+    private String email;
+    private String phone;
+    private JobCandidateInviteStatus inviteStatus;
+    private JobCandidateInterviewStatus interviewStatus;
+    private String resumeHtml;
+    private String resumeDocumentHtml;
+    private String fileName;
+    private String fileType;
+    private Instant uploadedAt;
+    private Float confidence;
+
+    public String getJobCandidateId() {
+        return jobCandidateId;
+    }
+
+    public void setJobCandidateId(String jobCandidateId) {
+        this.jobCandidateId = jobCandidateId;
+    }
+
+    public String getPositionId() {
+        return positionId;
+    }
+
+    public void setPositionId(String positionId) {
+        this.positionId = positionId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public JobCandidateInviteStatus getInviteStatus() {
+        return inviteStatus;
+    }
+
+    public void setInviteStatus(JobCandidateInviteStatus inviteStatus) {
+        this.inviteStatus = inviteStatus;
+    }
+
+    public JobCandidateInterviewStatus getInterviewStatus() {
+        return interviewStatus;
+    }
+
+    public void setInterviewStatus(JobCandidateInterviewStatus interviewStatus) {
+        this.interviewStatus = interviewStatus;
+    }
+
+    public String getResumeHtml() {
+        return resumeHtml;
+    }
+
+    public void setResumeHtml(String resumeHtml) {
+        this.resumeHtml = resumeHtml;
+    }
+
+    public String getResumeDocumentHtml() {
+        return resumeDocumentHtml;
+    }
+
+    public void setResumeDocumentHtml(String resumeDocumentHtml) {
+        this.resumeDocumentHtml = resumeDocumentHtml;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getFileType() {
+        return fileType;
+    }
+
+    public void setFileType(String fileType) {
+        this.fileType = fileType;
+    }
+
+    public Instant getUploadedAt() {
+        return uploadedAt;
+    }
+
+    public void setUploadedAt(Instant uploadedAt) {
+        this.uploadedAt = uploadedAt;
+    }
+
+    public Float getConfidence() {
+        return confidence;
+    }
+
+    public void setConfidence(Float confidence) {
+        this.confidence = confidence;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateStatusSummary.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateStatusSummary.java
@@ -1,0 +1,89 @@
+package com.example.grpcdemo.controller.dto;
+
+/**
+ * 岗位候选人状态聚合。
+ */
+public class JobCandidateStatusSummary {
+
+    private long invitePending;
+    private long inviteSent;
+    private long inviteFailed;
+    private long emailMissing;
+    private long interviewNotStarted;
+    private long interviewScheduled;
+    private long interviewInProgress;
+    private long interviewCompleted;
+    private long interviewCancelled;
+
+    public long getInvitePending() {
+        return invitePending;
+    }
+
+    public void setInvitePending(long invitePending) {
+        this.invitePending = invitePending;
+    }
+
+    public long getInviteSent() {
+        return inviteSent;
+    }
+
+    public void setInviteSent(long inviteSent) {
+        this.inviteSent = inviteSent;
+    }
+
+    public long getInviteFailed() {
+        return inviteFailed;
+    }
+
+    public void setInviteFailed(long inviteFailed) {
+        this.inviteFailed = inviteFailed;
+    }
+
+    public long getEmailMissing() {
+        return emailMissing;
+    }
+
+    public void setEmailMissing(long emailMissing) {
+        this.emailMissing = emailMissing;
+    }
+
+    public long getInterviewNotStarted() {
+        return interviewNotStarted;
+    }
+
+    public void setInterviewNotStarted(long interviewNotStarted) {
+        this.interviewNotStarted = interviewNotStarted;
+    }
+
+    public long getInterviewScheduled() {
+        return interviewScheduled;
+    }
+
+    public void setInterviewScheduled(long interviewScheduled) {
+        this.interviewScheduled = interviewScheduled;
+    }
+
+    public long getInterviewInProgress() {
+        return interviewInProgress;
+    }
+
+    public void setInterviewInProgress(long interviewInProgress) {
+        this.interviewInProgress = interviewInProgress;
+    }
+
+    public long getInterviewCompleted() {
+        return interviewCompleted;
+    }
+
+    public void setInterviewCompleted(long interviewCompleted) {
+        this.interviewCompleted = interviewCompleted;
+    }
+
+    public long getInterviewCancelled() {
+        return interviewCancelled;
+    }
+
+    public void setInterviewCancelled(long interviewCancelled) {
+        this.interviewCancelled = interviewCancelled;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateUpdateRequest.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateUpdateRequest.java
@@ -1,0 +1,76 @@
+package com.example.grpcdemo.controller.dto;
+
+import com.example.grpcdemo.entity.JobCandidateInterviewStatus;
+import com.example.grpcdemo.entity.JobCandidateInviteStatus;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 候选人信息更新请求。
+ */
+public class JobCandidateUpdateRequest {
+
+    @Size(max = 255, message = "姓名长度不能超过 255 字符")
+    private String name;
+
+    @Email(message = "邮箱格式不正确")
+    @Size(max = 255, message = "邮箱长度不能超过 255 字符")
+    private String email;
+
+    @Size(max = 64, message = "电话长度不能超过 64 字符")
+    private String phone;
+
+    private JobCandidateInviteStatus inviteStatus;
+
+    private JobCandidateInterviewStatus interviewStatus;
+
+    private String resumeHtml;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public JobCandidateInviteStatus getInviteStatus() {
+        return inviteStatus;
+    }
+
+    public void setInviteStatus(JobCandidateInviteStatus inviteStatus) {
+        this.inviteStatus = inviteStatus;
+    }
+
+    public JobCandidateInterviewStatus getInterviewStatus() {
+        return interviewStatus;
+    }
+
+    public void setInterviewStatus(JobCandidateInterviewStatus interviewStatus) {
+        this.interviewStatus = interviewStatus;
+    }
+
+    public String getResumeHtml() {
+        return resumeHtml;
+    }
+
+    public void setResumeHtml(String resumeHtml) {
+        this.resumeHtml = resumeHtml;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/entity/CompanyJobCandidateEntity.java
+++ b/src/main/java/com/example/grpcdemo/entity/CompanyJobCandidateEntity.java
@@ -1,0 +1,172 @@
+package com.example.grpcdemo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+/**
+ * 企业岗位下的候选人记录。
+ */
+@Entity
+@Table(name = "job_candidates")
+public class CompanyJobCandidateEntity {
+
+    @Id
+    @Column(name = "job_candidate_id", nullable = false, length = 36)
+    private String jobCandidateId;
+
+    @Column(name = "position_id", nullable = false, length = 36)
+    private String positionId;
+
+    @Column(name = "candidate_name", length = 255)
+    private String candidateName;
+
+    @Column(name = "candidate_email", length = 255)
+    private String candidateEmail;
+
+    @Column(name = "candidate_phone", length = 64)
+    private String candidatePhone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "invite_status", nullable = false, length = 32)
+    private JobCandidateInviteStatus inviteStatus = JobCandidateInviteStatus.INVITE_PENDING;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interview_status", nullable = false, length = 32)
+    private JobCandidateInterviewStatus interviewStatus = JobCandidateInterviewStatus.NOT_INTERVIEWED;
+
+    @Column(name = "resume_id", length = 36)
+    private String resumeId;
+
+    @Column(name = "uploader_user_id", length = 36)
+    private String uploaderUserId;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        if (updatedAt == null) {
+            updatedAt = now;
+        }
+        if (inviteStatus == null) {
+            inviteStatus = JobCandidateInviteStatus.INVITE_PENDING;
+        }
+        if (interviewStatus == null) {
+            interviewStatus = JobCandidateInterviewStatus.NOT_INTERVIEWED;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = Instant.now();
+        if (inviteStatus == null) {
+            inviteStatus = JobCandidateInviteStatus.INVITE_PENDING;
+        }
+        if (interviewStatus == null) {
+            interviewStatus = JobCandidateInterviewStatus.NOT_INTERVIEWED;
+        }
+    }
+
+    public String getJobCandidateId() {
+        return jobCandidateId;
+    }
+
+    public void setJobCandidateId(String jobCandidateId) {
+        this.jobCandidateId = jobCandidateId;
+    }
+
+    public String getPositionId() {
+        return positionId;
+    }
+
+    public void setPositionId(String positionId) {
+        this.positionId = positionId;
+    }
+
+    public String getCandidateName() {
+        return candidateName;
+    }
+
+    public void setCandidateName(String candidateName) {
+        this.candidateName = candidateName;
+    }
+
+    public String getCandidateEmail() {
+        return candidateEmail;
+    }
+
+    public void setCandidateEmail(String candidateEmail) {
+        this.candidateEmail = candidateEmail;
+    }
+
+    public String getCandidatePhone() {
+        return candidatePhone;
+    }
+
+    public void setCandidatePhone(String candidatePhone) {
+        this.candidatePhone = candidatePhone;
+    }
+
+    public JobCandidateInviteStatus getInviteStatus() {
+        return inviteStatus;
+    }
+
+    public void setInviteStatus(JobCandidateInviteStatus inviteStatus) {
+        this.inviteStatus = inviteStatus;
+    }
+
+    public JobCandidateInterviewStatus getInterviewStatus() {
+        return interviewStatus;
+    }
+
+    public void setInterviewStatus(JobCandidateInterviewStatus interviewStatus) {
+        this.interviewStatus = interviewStatus;
+    }
+
+    public String getResumeId() {
+        return resumeId;
+    }
+
+    public void setResumeId(String resumeId) {
+        this.resumeId = resumeId;
+    }
+
+    public String getUploaderUserId() {
+        return uploaderUserId;
+    }
+
+    public void setUploaderUserId(String uploaderUserId) {
+        this.uploaderUserId = uploaderUserId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/entity/JobCandidateInterviewStatus.java
+++ b/src/main/java/com/example/grpcdemo/entity/JobCandidateInterviewStatus.java
@@ -1,0 +1,17 @@
+package com.example.grpcdemo.entity;
+
+/**
+ * 面试状态枚举。
+ */
+public enum JobCandidateInterviewStatus {
+    /** 未安排或未开始面试。 */
+    NOT_INTERVIEWED,
+    /** 已安排面试，尚未完成。 */
+    SCHEDULED,
+    /** 面试进行中。 */
+    IN_PROGRESS,
+    /** 面试已完成。 */
+    COMPLETED,
+    /** 面试已取消或候选人放弃。 */
+    CANCELLED
+}

--- a/src/main/java/com/example/grpcdemo/entity/JobCandidateInviteStatus.java
+++ b/src/main/java/com/example/grpcdemo/entity/JobCandidateInviteStatus.java
@@ -1,0 +1,15 @@
+package com.example.grpcdemo.entity;
+
+/**
+ * 邀约状态。
+ */
+public enum JobCandidateInviteStatus {
+    /** 待邀约（已解析出邮箱）。 */
+    INVITE_PENDING,
+    /** 已发送邀约邮件。 */
+    INVITE_SENT,
+    /** 邮件发送失败。 */
+    INVITE_FAILED,
+    /** 邮箱缺失或无效，无法发送邀约。 */
+    EMAIL_MISSING
+}

--- a/src/main/java/com/example/grpcdemo/entity/JobCandidateResumeEntity.java
+++ b/src/main/java/com/example/grpcdemo/entity/JobCandidateResumeEntity.java
@@ -1,0 +1,182 @@
+package com.example.grpcdemo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+/**
+ * 候选人简历原始文件与解析结果。
+ */
+@Entity
+@Table(name = "job_candidate_resumes")
+public class JobCandidateResumeEntity {
+
+    @Id
+    @Column(name = "resume_id", nullable = false, length = 36)
+    private String resumeId;
+
+    @Column(name = "job_candidate_id", nullable = false, length = 36)
+    private String jobCandidateId;
+
+    @Column(name = "file_name", length = 255)
+    private String fileName;
+
+    @Column(name = "file_type", length = 100)
+    private String fileType;
+
+    @Lob
+    @Column(name = "file_content")
+    private byte[] fileContent;
+
+    @Column(name = "parsed_name", length = 255)
+    private String parsedName;
+
+    @Column(name = "parsed_email", length = 255)
+    private String parsedEmail;
+
+    @Column(name = "parsed_phone", length = 64)
+    private String parsedPhone;
+
+    @Lob
+    @Column(name = "parsed_html")
+    private String parsedHtml;
+
+    @Column(name = "confidence")
+    private Float confidence;
+
+    @Lob
+    @Column(name = "ai_raw_result")
+    private String aiRawResult;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        if (updatedAt == null) {
+            updatedAt = now;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    public String getResumeId() {
+        return resumeId;
+    }
+
+    public void setResumeId(String resumeId) {
+        this.resumeId = resumeId;
+    }
+
+    public String getJobCandidateId() {
+        return jobCandidateId;
+    }
+
+    public void setJobCandidateId(String jobCandidateId) {
+        this.jobCandidateId = jobCandidateId;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getFileType() {
+        return fileType;
+    }
+
+    public void setFileType(String fileType) {
+        this.fileType = fileType;
+    }
+
+    public byte[] getFileContent() {
+        return fileContent;
+    }
+
+    public void setFileContent(byte[] fileContent) {
+        this.fileContent = fileContent;
+    }
+
+    public String getParsedName() {
+        return parsedName;
+    }
+
+    public void setParsedName(String parsedName) {
+        this.parsedName = parsedName;
+    }
+
+    public String getParsedEmail() {
+        return parsedEmail;
+    }
+
+    public void setParsedEmail(String parsedEmail) {
+        this.parsedEmail = parsedEmail;
+    }
+
+    public String getParsedPhone() {
+        return parsedPhone;
+    }
+
+    public void setParsedPhone(String parsedPhone) {
+        this.parsedPhone = parsedPhone;
+    }
+
+    public String getParsedHtml() {
+        return parsedHtml;
+    }
+
+    public void setParsedHtml(String parsedHtml) {
+        this.parsedHtml = parsedHtml;
+    }
+
+    public Float getConfidence() {
+        return confidence;
+    }
+
+    public void setConfidence(Float confidence) {
+        this.confidence = confidence;
+    }
+
+    public String getAiRawResult() {
+        return aiRawResult;
+    }
+
+    public void setAiRawResult(String aiRawResult) {
+        this.aiRawResult = aiRawResult;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/grpcdemo/repository/CompanyJobCandidateRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/CompanyJobCandidateRepository.java
@@ -1,0 +1,33 @@
+package com.example.grpcdemo.repository;
+
+import com.example.grpcdemo.entity.CompanyJobCandidateEntity;
+import com.example.grpcdemo.entity.JobCandidateInviteStatus;
+import com.example.grpcdemo.entity.JobCandidateInterviewStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 岗位候选人存取仓储。
+ */
+public interface CompanyJobCandidateRepository extends JpaRepository<CompanyJobCandidateEntity, String> {
+
+    List<CompanyJobCandidateEntity> findByPositionIdOrderByCreatedAtDesc(String positionId);
+
+    @Query("SELECT c FROM CompanyJobCandidateEntity c WHERE c.positionId = :positionId AND "
+            + "(LOWER(c.candidateName) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+            + "OR LOWER(c.candidateEmail) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+            + "OR LOWER(c.candidatePhone) LIKE LOWER(CONCAT('%', :keyword, '%')))"
+            + " ORDER BY c.createdAt DESC")
+    List<CompanyJobCandidateEntity> searchByKeyword(@Param("positionId") String positionId,
+                                                    @Param("keyword") String keyword);
+
+    long countByPositionIdAndInviteStatus(String positionId, JobCandidateInviteStatus status);
+
+    long countByPositionIdAndInterviewStatus(String positionId, JobCandidateInterviewStatus status);
+
+    Optional<CompanyJobCandidateEntity> findByJobCandidateIdAndPositionId(String jobCandidateId, String positionId);
+}

--- a/src/main/java/com/example/grpcdemo/repository/CompanyRecruitingPositionRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/CompanyRecruitingPositionRepository.java
@@ -14,6 +14,9 @@ public interface CompanyRecruitingPositionRepository extends JpaRepository<Compa
 
     List<CompanyRecruitingPositionEntity> findByCompanyIdOrderByUpdatedAtDesc(String companyId);
 
+    List<CompanyRecruitingPositionEntity> findByCompanyIdAndPositionNameContainingIgnoreCaseOrderByUpdatedAtDesc(
+            String companyId, String keyword);
+
     long countByCompanyId(String companyId);
 }
 

--- a/src/main/java/com/example/grpcdemo/repository/JobCandidateResumeRepository.java
+++ b/src/main/java/com/example/grpcdemo/repository/JobCandidateResumeRepository.java
@@ -1,0 +1,14 @@
+package com.example.grpcdemo.repository;
+
+import com.example.grpcdemo.entity.JobCandidateResumeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * 候选人简历仓储。
+ */
+public interface JobCandidateResumeRepository extends JpaRepository<JobCandidateResumeEntity, String> {
+
+    Optional<JobCandidateResumeEntity> findByJobCandidateId(String jobCandidateId);
+}

--- a/src/main/java/com/example/grpcdemo/service/CompanyJobCandidateService.java
+++ b/src/main/java/com/example/grpcdemo/service/CompanyJobCandidateService.java
@@ -1,0 +1,375 @@
+package com.example.grpcdemo.service;
+
+import com.example.grpcdemo.controller.dto.JobCandidateImportResponse;
+import com.example.grpcdemo.controller.dto.JobCandidateInviteRequest;
+import com.example.grpcdemo.controller.dto.JobCandidateItemResponse;
+import com.example.grpcdemo.controller.dto.JobCandidateListResponse;
+import com.example.grpcdemo.controller.dto.JobCandidateResumeResponse;
+import com.example.grpcdemo.controller.dto.JobCandidateStatusSummary;
+import com.example.grpcdemo.controller.dto.JobCandidateUpdateRequest;
+import com.example.grpcdemo.entity.CompanyJobCandidateEntity;
+import com.example.grpcdemo.entity.CompanyRecruitingPositionEntity;
+import com.example.grpcdemo.entity.InvitationTemplateEntity;
+import com.example.grpcdemo.entity.JobCandidateInterviewStatus;
+import com.example.grpcdemo.entity.JobCandidateInviteStatus;
+import com.example.grpcdemo.entity.JobCandidateResumeEntity;
+import com.example.grpcdemo.repository.CompanyJobCandidateRepository;
+import com.example.grpcdemo.repository.CompanyRecruitingPositionRepository;
+import com.example.grpcdemo.repository.InvitationTemplateRepository;
+import com.example.grpcdemo.repository.JobCandidateResumeRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * 企业岗位候选人相关业务逻辑。
+ */
+@Service
+public class CompanyJobCandidateService {
+
+    private static final Logger log = LoggerFactory.getLogger(CompanyJobCandidateService.class);
+
+    private final CompanyRecruitingPositionRepository positionRepository;
+    private final CompanyJobCandidateRepository candidateRepository;
+    private final JobCandidateResumeRepository resumeRepository;
+    private final InvitationTemplateRepository invitationTemplateRepository;
+    private final ResumeParser resumeParser;
+    private final JavaMailSender mailSender;
+
+    public CompanyJobCandidateService(CompanyRecruitingPositionRepository positionRepository,
+                                      CompanyJobCandidateRepository candidateRepository,
+                                      JobCandidateResumeRepository resumeRepository,
+                                      InvitationTemplateRepository invitationTemplateRepository,
+                                      ResumeParser resumeParser,
+                                      JavaMailSender mailSender) {
+        this.positionRepository = positionRepository;
+        this.candidateRepository = candidateRepository;
+        this.resumeRepository = resumeRepository;
+        this.invitationTemplateRepository = invitationTemplateRepository;
+        this.resumeParser = resumeParser;
+        this.mailSender = mailSender;
+    }
+
+    @Transactional
+    public JobCandidateImportResponse importCandidates(String positionId,
+                                                       String uploaderUserId,
+                                                       List<MultipartFile> files) {
+        if (!StringUtils.hasText(positionId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "缺少岗位 ID");
+        }
+        if (!StringUtils.hasText(uploaderUserId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "缺少上传者信息");
+        }
+        if (CollectionUtils.isEmpty(files)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "至少上传一份简历");
+        }
+        CompanyRecruitingPositionEntity position = requirePosition(positionId);
+        List<JobCandidateItemResponse> imported = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            if (file == null || file.isEmpty()) {
+                continue;
+            }
+            String fileName = file.getOriginalFilename();
+            String contentType = file.getContentType();
+            byte[] content;
+            try {
+                content = file.getBytes();
+            } catch (IOException e) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "读取上传文件失败", e);
+            }
+            ResumeParsingResult parsingResult = null;
+            String error = null;
+            try {
+                parsingResult = resumeParser.parse(new ResumeParsingCommand(content,
+                        fileName,
+                        contentType,
+                        position.getCompanyId(),
+                        positionId,
+                        uploaderUserId));
+            } catch (ResumeParsingException e) {
+                error = e.getMessage();
+                log.warn("解析简历 {} 失败: {}", fileName, e.getMessage());
+            }
+
+            CompanyJobCandidateEntity candidate = new CompanyJobCandidateEntity();
+            String candidateId = UUID.randomUUID().toString();
+            candidate.setJobCandidateId(candidateId);
+            candidate.setPositionId(positionId);
+            candidate.setUploaderUserId(uploaderUserId);
+
+            String parsedName = parsingResult != null ? parsingResult.getName() : null;
+            if (!StringUtils.hasText(parsedName)) {
+                parsedName = deriveNameFromFile(fileName);
+            }
+            candidate.setCandidateName(parsedName);
+            candidate.setCandidateEmail(parsingResult != null ? normalize(parsingResult.getEmail()) : null);
+            candidate.setCandidatePhone(parsingResult != null ? normalize(parsingResult.getPhone()) : null);
+            if (!StringUtils.hasText(candidate.getCandidateEmail())) {
+                candidate.setInviteStatus(JobCandidateInviteStatus.EMAIL_MISSING);
+            } else {
+                candidate.setInviteStatus(JobCandidateInviteStatus.INVITE_PENDING);
+            }
+            candidate.setInterviewStatus(JobCandidateInterviewStatus.NOT_INTERVIEWED);
+
+            CompanyJobCandidateEntity savedCandidate = candidateRepository.save(candidate);
+
+            JobCandidateResumeEntity resume = new JobCandidateResumeEntity();
+            String resumeId = UUID.randomUUID().toString();
+            resume.setResumeId(resumeId);
+            resume.setJobCandidateId(candidateId);
+            resume.setFileName(fileName);
+            resume.setFileType(contentType);
+            resume.setFileContent(content);
+            if (parsingResult != null) {
+                resume.setParsedName(parsingResult.getName());
+                resume.setParsedEmail(parsingResult.getEmail());
+                resume.setParsedPhone(parsingResult.getPhone());
+                resume.setParsedHtml(parsingResult.getHtmlContent());
+                resume.setConfidence(parsingResult.getConfidence());
+                resume.setAiRawResult(parsingResult.getRawJson());
+            } else {
+                resume.setAiRawResult(error);
+            }
+            resumeRepository.save(resume);
+
+            savedCandidate.setResumeId(resumeId);
+            candidateRepository.save(savedCandidate);
+
+            imported.add(toItemResponse(savedCandidate));
+        }
+        JobCandidateImportResponse response = new JobCandidateImportResponse();
+        response.setImportedCandidates(imported);
+        response.setSummary(buildSummary(positionId));
+        return response;
+    }
+
+    @Transactional(readOnly = true)
+    public JobCandidateListResponse listCandidates(String positionId, String keyword) {
+        requirePosition(positionId);
+        List<CompanyJobCandidateEntity> entities;
+        if (StringUtils.hasText(keyword)) {
+            entities = candidateRepository.searchByKeyword(positionId, keyword.trim());
+        } else {
+            entities = candidateRepository.findByPositionIdOrderByCreatedAtDesc(positionId);
+        }
+        List<JobCandidateItemResponse> items = entities.stream()
+                .map(this::toItemResponse)
+                .toList();
+        JobCandidateListResponse response = new JobCandidateListResponse();
+        response.setCandidates(items);
+        response.setSummary(buildSummary(positionId));
+        return response;
+    }
+
+    @Transactional(readOnly = true)
+    public JobCandidateResumeResponse getResume(String jobCandidateId) {
+        CompanyJobCandidateEntity candidate = candidateRepository.findById(jobCandidateId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "候选人不存在"));
+        JobCandidateResumeResponse response = new JobCandidateResumeResponse();
+        response.setJobCandidateId(candidate.getJobCandidateId());
+        response.setPositionId(candidate.getPositionId());
+        response.setName(candidate.getCandidateName());
+        response.setEmail(candidate.getCandidateEmail());
+        response.setPhone(candidate.getCandidatePhone());
+        response.setInviteStatus(candidate.getInviteStatus());
+        response.setInterviewStatus(candidate.getInterviewStatus());
+
+        if (StringUtils.hasText(candidate.getResumeId())) {
+            Optional<JobCandidateResumeEntity> resumeOpt = resumeRepository.findById(candidate.getResumeId());
+            resumeOpt.ifPresent(resume -> {
+                response.setFileName(resume.getFileName());
+                response.setFileType(resume.getFileType());
+                response.setResumeHtml(resume.getParsedHtml());
+                response.setResumeDocumentHtml(buildDocumentHtml(resume.getFileContent(), resume.getFileType()));
+                response.setUploadedAt(resume.getCreatedAt());
+                response.setConfidence(resume.getConfidence());
+            });
+        }
+        return response;
+    }
+
+    @Transactional
+    public JobCandidateItemResponse updateCandidate(String jobCandidateId, JobCandidateUpdateRequest request) {
+        CompanyJobCandidateEntity candidate = candidateRepository.findById(jobCandidateId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "候选人不存在"));
+        boolean changed = false;
+        if (request.getName() != null) {
+            candidate.setCandidateName(StringUtils.hasText(request.getName()) ? request.getName().trim() : null);
+            changed = true;
+        }
+        if (request.getEmail() != null) {
+            String email = StringUtils.hasText(request.getEmail()) ? request.getEmail().trim() : null;
+            candidate.setCandidateEmail(email);
+            if (!StringUtils.hasText(email)) {
+                candidate.setInviteStatus(JobCandidateInviteStatus.EMAIL_MISSING);
+            } else if (candidate.getInviteStatus() == JobCandidateInviteStatus.EMAIL_MISSING) {
+                candidate.setInviteStatus(JobCandidateInviteStatus.INVITE_PENDING);
+            }
+            changed = true;
+        }
+        if (request.getPhone() != null) {
+            candidate.setCandidatePhone(StringUtils.hasText(request.getPhone()) ? request.getPhone().trim() : null);
+            changed = true;
+        }
+        if (request.getInviteStatus() != null) {
+            candidate.setInviteStatus(request.getInviteStatus());
+            changed = true;
+        }
+        if (request.getInterviewStatus() != null) {
+            candidate.setInterviewStatus(request.getInterviewStatus());
+            changed = true;
+        }
+        if (changed) {
+            candidate.setUpdatedAt(Instant.now());
+        }
+        candidateRepository.save(candidate);
+
+        if (request.getResumeHtml() != null && StringUtils.hasText(candidate.getResumeId())) {
+            resumeRepository.findById(candidate.getResumeId()).ifPresent(resume -> {
+                resume.setParsedHtml(request.getResumeHtml());
+                if (request.getName() != null) {
+                    resume.setParsedName(candidate.getCandidateName());
+                }
+                if (request.getEmail() != null) {
+                    resume.setParsedEmail(candidate.getCandidateEmail());
+                }
+                if (request.getPhone() != null) {
+                    resume.setParsedPhone(candidate.getCandidatePhone());
+                }
+                resumeRepository.save(resume);
+            });
+        }
+        return toItemResponse(candidate);
+    }
+
+    @Transactional
+    public JobCandidateItemResponse sendInvite(String jobCandidateId, JobCandidateInviteRequest request) {
+        CompanyJobCandidateEntity candidate = candidateRepository.findById(jobCandidateId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "候选人不存在"));
+        if (!StringUtils.hasText(candidate.getCandidateEmail())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "候选人缺少邮箱，无法发送邀约");
+        }
+        CompanyRecruitingPositionEntity position = requirePosition(candidate.getPositionId());
+        InvitationTemplateEntity template = resolveTemplate(position.getCompanyId(), request);
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(candidate.getCandidateEmail());
+            message.setSubject(template.getSubject());
+            message.setText(template.getBody());
+            if (request != null && !CollectionUtils.isEmpty(request.getCc())) {
+                message.setCc(request.getCc().toArray(new String[0]));
+            }
+            mailSender.send(message);
+            candidate.setInviteStatus(JobCandidateInviteStatus.INVITE_SENT);
+            candidate.setUpdatedAt(Instant.now());
+            candidateRepository.save(candidate);
+            return toItemResponse(candidate);
+        } catch (MailException e) {
+            candidate.setInviteStatus(JobCandidateInviteStatus.INVITE_FAILED);
+            candidate.setUpdatedAt(Instant.now());
+            candidateRepository.save(candidate);
+            log.error("发送邀约邮件失败: {}", e.getMessage(), e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "发送邀约邮件失败", e);
+        }
+    }
+
+    private InvitationTemplateEntity resolveTemplate(String companyId, JobCandidateInviteRequest request) {
+        if (request != null && StringUtils.hasText(request.getTemplateId())) {
+            InvitationTemplateEntity template = invitationTemplateRepository.findById(request.getTemplateId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "邀约模版不存在"));
+            if (!template.getCompanyId().equals(companyId)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "模版不属于当前企业");
+            }
+            return template;
+        }
+        return invitationTemplateRepository.findFirstByCompanyIdAndDefaultTemplateTrue(companyId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "企业未配置默认邀约模版"));
+    }
+
+    private CompanyRecruitingPositionEntity requirePosition(String positionId) {
+        return positionRepository.findById(positionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "岗位不存在"));
+    }
+
+    private JobCandidateStatusSummary buildSummary(String positionId) {
+        JobCandidateStatusSummary summary = new JobCandidateStatusSummary();
+        summary.setInvitePending(candidateRepository.countByPositionIdAndInviteStatus(positionId, JobCandidateInviteStatus.INVITE_PENDING));
+        summary.setInviteSent(candidateRepository.countByPositionIdAndInviteStatus(positionId, JobCandidateInviteStatus.INVITE_SENT));
+        summary.setInviteFailed(candidateRepository.countByPositionIdAndInviteStatus(positionId, JobCandidateInviteStatus.INVITE_FAILED));
+        summary.setEmailMissing(candidateRepository.countByPositionIdAndInviteStatus(positionId, JobCandidateInviteStatus.EMAIL_MISSING));
+        summary.setInterviewNotStarted(candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.NOT_INTERVIEWED));
+        summary.setInterviewScheduled(candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.SCHEDULED));
+        summary.setInterviewInProgress(candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.IN_PROGRESS));
+        summary.setInterviewCompleted(candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.COMPLETED));
+        summary.setInterviewCancelled(candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.CANCELLED));
+        return summary;
+    }
+
+    private JobCandidateItemResponse toItemResponse(CompanyJobCandidateEntity entity) {
+        boolean emailMissing = entity.getInviteStatus() == JobCandidateInviteStatus.EMAIL_MISSING
+                || !StringUtils.hasText(entity.getCandidateEmail());
+        boolean resumeAvailable = StringUtils.hasText(entity.getResumeId());
+        return new JobCandidateItemResponse(entity.getJobCandidateId(),
+                entity.getPositionId(),
+                entity.getCandidateName(),
+                entity.getCandidateEmail(),
+                entity.getCandidatePhone(),
+                entity.getInviteStatus(),
+                entity.getInterviewStatus(),
+                emailMissing,
+                resumeAvailable,
+                entity.getCreatedAt(),
+                entity.getUpdatedAt());
+    }
+
+    private String buildDocumentHtml(byte[] content, String fileType) {
+        if (content == null || content.length == 0) {
+            return null;
+        }
+        String mimeType = StringUtils.hasText(fileType) ? fileType : "application/pdf";
+        String base64 = Base64.getEncoder().encodeToString(content);
+        return "<iframe src=\"data:" + mimeType + ";base64," + base64
+                + "\" style=\"width:100%;height:100%;border:none;\"></iframe>";
+    }
+
+    private String deriveNameFromFile(String fileName) {
+        if (!StringUtils.hasText(fileName)) {
+            return "未命名候选人";
+        }
+        String name = fileName;
+        int slash = Math.max(fileName.lastIndexOf('/'), fileName.lastIndexOf('\\'));
+        if (slash >= 0 && slash < fileName.length() - 1) {
+            name = fileName.substring(slash + 1);
+        }
+        int dot = name.lastIndexOf('.');
+        if (dot > 0) {
+            name = name.substring(0, dot);
+        }
+        return name;
+    }
+
+    private String normalize(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/com/example/grpcdemo/service/CompanyJobService.java
+++ b/src/main/java/com/example/grpcdemo/service/CompanyJobService.java
@@ -62,9 +62,16 @@ public class CompanyJobService {
     }
 
     @Transactional(readOnly = true)
-    public List<JobCardResponse> listCards(String companyId, String userId) {
+    public List<JobCardResponse> listCards(String companyId, String userId, String keyword) {
         String resolvedCompanyId = resolveCompanyId(companyId, userId);
-        return recruitingPositionRepository.findByCompanyIdOrderByUpdatedAtDesc(resolvedCompanyId).stream()
+        List<CompanyRecruitingPositionEntity> positions;
+        if (StringUtils.hasText(keyword)) {
+            positions = recruitingPositionRepository
+                    .findByCompanyIdAndPositionNameContainingIgnoreCaseOrderByUpdatedAtDesc(resolvedCompanyId, keyword.trim());
+        } else {
+            positions = recruitingPositionRepository.findByCompanyIdOrderByUpdatedAtDesc(resolvedCompanyId);
+        }
+        return positions.stream()
                 .map(this::toCard)
                 .toList();
     }

--- a/src/main/java/com/example/grpcdemo/service/RestResumeParser.java
+++ b/src/main/java/com/example/grpcdemo/service/RestResumeParser.java
@@ -1,0 +1,82 @@
+package com.example.grpcdemo.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.Duration;
+import java.util.Base64;
+
+/**
+ * 默认实现，调用外部 AI 简历解析服务。
+ */
+@Service
+@Profile("!test")
+public class RestResumeParser implements ResumeParser {
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    public RestResumeParser(WebClient.Builder builder,
+                            @Value("${ai.resume-parser.base-url}") String baseUrl,
+                            ObjectMapper objectMapper) {
+        this.webClient = builder
+                .baseUrl(baseUrl)
+                .build();
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public ResumeParsingResult parse(ResumeParsingCommand command) {
+        try {
+            String content = Base64.getEncoder().encodeToString(command.getFileContent());
+            ResumeParserResponse body = webClient.post()
+                    .uri("/resumes:parse")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(new ResumeParserRequest(command.getFileName(),
+                            command.getContentType(),
+                            command.getCompanyId(),
+                            command.getPositionId(),
+                            command.getUploaderUserId(),
+                            content))
+                    .retrieve()
+                    .bodyToMono(ResumeParserResponse.class)
+                    .block(Duration.ofSeconds(20));
+
+            if (body == null) {
+                throw new ResumeParsingException("AI 简历解析服务返回空响应");
+            }
+            String rawJson = null;
+            if (body.raw() != null) {
+                rawJson = objectMapper.writeValueAsString(body.raw());
+            }
+            return new ResumeParsingResult(body.name(), body.email(), body.phone(), body.htmlContent(), body.confidence(), rawJson);
+        } catch (WebClientResponseException e) {
+            throw new ResumeParsingException("AI 简历解析服务返回错误: " + e.getStatusCode(), e);
+        } catch (ResumeParsingException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ResumeParsingException("调用 AI 简历解析服务失败", e);
+        }
+    }
+
+    private record ResumeParserRequest(String fileName,
+                                       String contentType,
+                                       String companyId,
+                                       String positionId,
+                                       String uploaderUserId,
+                                       String contentBase64) {
+    }
+
+    private record ResumeParserResponse(String name,
+                                        String email,
+                                        String phone,
+                                        String htmlContent,
+                                        Float confidence,
+                                        Object raw) {
+    }
+}

--- a/src/main/java/com/example/grpcdemo/service/ResumeParser.java
+++ b/src/main/java/com/example/grpcdemo/service/ResumeParser.java
@@ -1,0 +1,15 @@
+package com.example.grpcdemo.service;
+
+/**
+ * 定义简历解析行为的接口。
+ */
+public interface ResumeParser {
+
+    /**
+     * 调用外部 AI 服务解析上传的简历。
+     *
+     * @param command 解析命令
+     * @return 解析结果
+     */
+    ResumeParsingResult parse(ResumeParsingCommand command);
+}

--- a/src/main/java/com/example/grpcdemo/service/ResumeParsingCommand.java
+++ b/src/main/java/com/example/grpcdemo/service/ResumeParsingCommand.java
@@ -1,0 +1,91 @@
+package com.example.grpcdemo.service;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * 简历解析指令。
+ */
+public final class ResumeParsingCommand {
+
+    private final byte[] fileContent;
+    private final String fileName;
+    private final String contentType;
+    private final String companyId;
+    private final String positionId;
+    private final String uploaderUserId;
+
+    public ResumeParsingCommand(byte[] fileContent,
+                                String fileName,
+                                String contentType,
+                                String companyId,
+                                String positionId,
+                                String uploaderUserId) {
+        this.fileContent = Objects.requireNonNull(fileContent, "fileContent");
+        this.fileName = fileName;
+        this.contentType = contentType;
+        this.companyId = companyId;
+        this.positionId = positionId;
+        this.uploaderUserId = uploaderUserId;
+    }
+
+    public byte[] getFileContent() {
+        return fileContent;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public String getCompanyId() {
+        return companyId;
+    }
+
+    public String getPositionId() {
+        return positionId;
+    }
+
+    public String getUploaderUserId() {
+        return uploaderUserId;
+    }
+
+    @Override
+    public String toString() {
+        return "ResumeParsingCommand{" +
+                "fileName='" + fileName + '\'' +
+                ", contentType='" + contentType + '\'' +
+                ", companyId='" + companyId + '\'' +
+                ", positionId='" + positionId + '\'' +
+                ", uploaderUserId='" + uploaderUserId + '\'' +
+                ", fileContentLength=" + (fileContent != null ? fileContent.length : 0) +
+                '}';
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(fileName, contentType, companyId, positionId, uploaderUserId);
+        result = 31 * result + Arrays.hashCode(fileContent);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ResumeParsingCommand that = (ResumeParsingCommand) obj;
+        return Arrays.equals(fileContent, that.fileContent)
+                && Objects.equals(fileName, that.fileName)
+                && Objects.equals(contentType, that.contentType)
+                && Objects.equals(companyId, that.companyId)
+                && Objects.equals(positionId, that.positionId)
+                && Objects.equals(uploaderUserId, that.uploaderUserId);
+    }
+}

--- a/src/main/java/com/example/grpcdemo/service/ResumeParsingException.java
+++ b/src/main/java/com/example/grpcdemo/service/ResumeParsingException.java
@@ -1,0 +1,15 @@
+package com.example.grpcdemo.service;
+
+/**
+ * 简历解析异常。
+ */
+public class ResumeParsingException extends RuntimeException {
+
+    public ResumeParsingException(String message) {
+        super(message);
+    }
+
+    public ResumeParsingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/grpcdemo/service/ResumeParsingResult.java
+++ b/src/main/java/com/example/grpcdemo/service/ResumeParsingResult.java
@@ -1,0 +1,90 @@
+package com.example.grpcdemo.service;
+
+import java.util.Objects;
+
+/**
+ * 简历解析结果。
+ */
+public final class ResumeParsingResult {
+
+    private final String name;
+    private final String email;
+    private final String phone;
+    private final String htmlContent;
+    private final Float confidence;
+    private final String rawJson;
+
+    public ResumeParsingResult(String name,
+                               String email,
+                               String phone,
+                               String htmlContent,
+                               Float confidence,
+                               String rawJson) {
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+        this.htmlContent = htmlContent;
+        this.confidence = confidence;
+        this.rawJson = rawJson;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public String getHtmlContent() {
+        return htmlContent;
+    }
+
+    public Float getConfidence() {
+        return confidence;
+    }
+
+    public String getRawJson() {
+        return rawJson;
+    }
+
+    public boolean hasContact() {
+        return (email != null && !email.isBlank()) || (phone != null && !phone.isBlank());
+    }
+
+    @Override
+    public String toString() {
+        return "ResumeParsingResult{" +
+                "name='" + name + '\'' +
+                ", email='" + email + '\'' +
+                ", phone='" + phone + '\'' +
+                ", confidence=" + confidence +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResumeParsingResult that = (ResumeParsingResult) o;
+        return Objects.equals(name, that.name)
+                && Objects.equals(email, that.email)
+                && Objects.equals(phone, that.phone)
+                && Objects.equals(htmlContent, that.htmlContent)
+                && Objects.equals(confidence, that.confidence)
+                && Objects.equals(rawJson, that.rawJson);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, email, phone, htmlContent, confidence, rawJson);
+    }
+}

--- a/src/main/java/com/example/grpcdemo/service/StubResumeParser.java
+++ b/src/main/java/com/example/grpcdemo/service/StubResumeParser.java
@@ -1,0 +1,31 @@
+package com.example.grpcdemo.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.util.Base64;
+
+/**
+ * 测试环境使用的占位解析器，直接从文件名生成基础信息。
+ */
+@Service
+@Profile("test")
+public class StubResumeParser implements ResumeParser {
+
+    private static final Logger log = LoggerFactory.getLogger(StubResumeParser.class);
+
+    @Override
+    public ResumeParsingResult parse(ResumeParsingCommand command) {
+        String fileName = command.getFileName() != null ? command.getFileName() : "unknown.pdf";
+        String candidateName = fileName.contains(".") ? fileName.substring(0, fileName.lastIndexOf('.')) : fileName;
+        if (candidateName.length() > 50) {
+            candidateName = candidateName.substring(0, 50);
+        }
+        String html = "<p>Stub resume preview for " + candidateName + "</p>";
+        String raw = Base64.getEncoder().encodeToString(command.getFileContent());
+        log.info("Stub resume parser invoked for file {}", fileName);
+        return new ResumeParsingResult(candidateName, candidateName + "@example.com", "", html, 0.0f, raw);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,5 @@ ai:
     base-url: http://localhost:8085
   job-parser:
     base-url: http://localhost:8090
+  resume-parser:
+    base-url: http://localhost:8091

--- a/技术接口文档&数据库基本结构.md
+++ b/技术接口文档&数据库基本结构.md
@@ -209,30 +209,30 @@
      | `TIMEOUT`        | 已超时         | 邀约超过 15 天未响应          |
      | `EMAIL_MISSING`  | 邮箱缺失        | 解析未得到邮箱               |
      | `INVALID`        | 解析失败        | AI 解析异常或文件损坏          |
-   ## 3.API 设计
+  ## 3.API 设计
      1）候选人批量导入
-       接口：POST /api/jobs/{jobId}/candidates/import
-       请求：multipart/form-data
-         files[]: 简历文件列表
-         uploaderId: 当前用户 ID
-      2）查询岗位候选人列表
-        接口：GET /api/jobs/{jobId}/candidates
-        查询参数：keyword（姓名/邮箱/电话）、status、page、size
-      3）更新候选人基础信息
-        接口：PATCH /api/candidates/{candidateId}
-      4）获取候选人简历详情
-        接口：GET /api/candidates/{candidateId}/resume
-      5）发送面试邀约邮件
-        接口：POST /api/job-candidates/{jobCandidateId}/invite
-      6）查询面试记录与报告
-         面试记录：GET /api/job-candidates/{jobCandidateId}/interview-records
-         返回问答列表、答题时间、录音/转写链接。
-         AI 评估报告：GET /api/job-candidates/{jobCandidateId}/report
-         若未生成则返回 404 REPORT_NOT_READY。
-      7）候选人状态维护
-        超时处理：后台定时任务扫描 INVITE_SENT 且超 15 天未开始的记录，更新为 TIMEOUT。
-        放弃面试：候选人在邮件或候选人端点击“放弃”，调用 POST /api/job-candidates/{jobCandidateId}/decline 更新状态为 DECLINED。
-        状态同步：面试完成后，Interview Service 发事件或调用 PATCH /api/job-candidates/{jobCandidateId}/status 更新状态为 COMPLETED，并触发报告生成流程。
+       - 接口：`POST /api/enterprise/jobs/{positionId}/candidates/import`
+       - `multipart/form-data`，参数：`uploaderUserId`（必填）+ `files[]`（必填，可多份）。
+       - 后端逐份调用 AI 简历解析器，产出姓名/邮箱/电话/HTML 文本；若解析失败依旧建档但标记邮箱缺失。
+     2）查询岗位候选人列表
+       - 接口：`GET /api/enterprise/jobs/{positionId}/candidates`
+       - 查询参数：`keyword`（姓名/邮箱/电话模糊搜索，可空）。
+       - 返回 `JobCandidateListResponse`，包含候选人数组及 `summary`（待邀约、已邀约、邮箱缺失、面试进度等聚合计数）。
+     3）更新候选人基础信息
+       - 接口：`PATCH /api/enterprise/job-candidates/{jobCandidateId}`
+       - 请求体：`JobCandidateUpdateRequest`，支持更新姓名、邮箱、电话、邀约状态、面试状态及可编辑的 `resumeHtml`。
+       - 邮箱清空会自动重置 `inviteStatus=EMAIL_MISSING`，补齐邮箱默认回到 `INVITE_PENDING`。
+     4）获取候选人简历详情
+       - 接口：`GET /api/enterprise/job-candidates/{jobCandidateId}/resume`
+       - 返回 `JobCandidateResumeResponse`，包含基本信息、AI 解析 HTML 片段，以及可直接 `<iframe>` 展示的原始 PDF。
+     5）发送面试邀约邮件
+       - 接口：`POST /api/enterprise/job-candidates/{jobCandidateId}/invite`
+       - 请求体：`JobCandidateInviteRequest`，可指定 `templateId` 或附加 `cc[]`；若不传则使用企业默认模版。
+       - 成功后写入 `inviteStatus=INVITE_SENT`，失败写入 `INVITE_FAILED` 并返回 500。
+     6）岗位搜索增强
+       - `GET /api/enterprise/jobs` 新增 `keyword` 参数，后端按岗位名称模糊筛选。
+     7）后续扩展（暂未实现）
+       - 面试记录、AI 报告查询、状态同步任务保留原设计接口，待面试服务落地后接入。
    ## 4.AI服务交互
     | 场景     | 调用方向                                      | 接口                 | 说明                               |
     | 简历解析   | Candidate Service → AI Resume Parser      | `POST /internal/ai/resume-parser`      | 输入简历文件 URL，输出姓名/邮箱/电话/教育经历等结构化数据 |
@@ -240,7 +240,32 @@
     | 语音转文字  | Interview Service → AI Speech-to-Text     | `POST /internal/ai/stt`                | 上传音频，返回转写文本 |
     | 面试评估   | Report Service → AI Evaluation            | `POST /internal/ai/evaluate`           | 输入问答内容，返回评分和评语 |
    ## 5.数据库设计
-     candidates表，job_candidates表，candidate_resumes表，notifications表，interviews / interview_records表，具体暂时省略
+     job_candidates 表（岗位-候选人关联）
+      | 字段 | 类型 | 说明 |
+      | `job_candidate_id` | UUID (PK) | 候选人记录 ID |
+      | `position_id` | UUID | 关联岗位 ID，外键指向 `company_recruiting_positions` |
+      | `candidate_name` | VARCHAR(255) | 候选人姓名（AI 解析或人工维护）|
+      | `candidate_email` | VARCHAR(255) | 邮箱，缺失时 `invite_status=EMAIL_MISSING` |
+      | `candidate_phone` | VARCHAR(64) | 联系电话 |
+      | `invite_status` | ENUM | `INVITE_PENDING` / `INVITE_SENT` / `INVITE_FAILED` / `EMAIL_MISSING` |
+      | `interview_status` | ENUM | `NOT_INTERVIEWED` / `SCHEDULED` / `IN_PROGRESS` / `COMPLETED` / `CANCELLED` |
+      | `resume_id` | UUID | 关联 `job_candidate_resumes`（1:1，可空）|
+      | `uploader_user_id` | UUID | 导入人用户 ID |
+      | `created_at` / `updated_at` | TIMESTAMP | 审计字段 |
+
+     job_candidate_resumes 表（简历原文及解析快照）
+      | 字段 | 类型 | 说明 |
+      | `resume_id` | UUID (PK) | 简历记录 ID |
+      | `job_candidate_id` | UUID | 外键，级联删除 |
+      | `file_name` / `file_type` | VARCHAR | 上传原始文件信息 |
+      | `file_content` | BYTEA | 原始 PDF 二进制，用于预览 |
+      | `parsed_name` / `parsed_email` / `parsed_phone` | VARCHAR | AI 解析出的关键信息 |
+      | `parsed_html` | TEXT | AI 解析的 HTML 富文本（可编辑）|
+      | `confidence` | DECIMAL(5,2) | AI 置信度 |
+      | `ai_raw_result` | TEXT | AI 返回的原始 JSON 或错误消息 |
+      | `created_at` / `updated_at` | TIMESTAMP | 审计字段 |
+
+     后续落地面试模块时，将在此基础上扩展 `interviews`、`interview_records` 等表，并通过事件或定时任务维护 `interview_status`。
   
   # 六,候选人后端功能
    ## 1.功能概述


### PR DESCRIPTION
## Summary
- add REST endpoints, service layer, and persistence models to import resumes per job, manage candidates, and send invitation emails
- integrate an AI resume parser (REST + stub) and expose resume previews/editing along with status summaries
- document the new flows, extend the SQL schema with job candidate tables, and support keyword search on job cards

## Testing
- `mvn -q -DskipTests compile` *(fails: parent POM unavailable in sandbox, Maven Central returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e1995c56688331a2c12510e0b2e129