### PR TITLE
Fix onboarding record localization

### DIFF
--- a/src/main/java/com/example/grpcdemo/service/EnterpriseOnboardingService.java
+++ b/src/main/java/com/example/grpcdemo/service/EnterpriseOnboardingService.java
@@ -395,7 +395,6 @@ public class EnterpriseOnboardingService {
         response.setTemplateInfo(session.getStep3() != null ? toTemplateDto(session.getStep3()) : null);
 
         response.setRecords(localizeRecords(session.toRecordDtos(), locale));
-        response.setRecords(session.toRecordDtos());
       
         Step3Data step3 = session.getStep3();
         return populateAvailableVariables(response, preferredLanguage, step3 != null ? step3.language : null);
@@ -420,7 +419,6 @@ public class EnterpriseOnboardingService {
         response.setTemplateInfo(toTemplateDto(step3));
 
         response.setRecords(localizeRecords(records, locale));
-        response.setRecords(records);
 
         return populateAvailableVariables(response, preferredLanguage, step3 != null ? step3.language : null);
     }

--- a/src/test/java/com/example/grpcdemo/service/EnterpriseOnboardingServiceTest.java
+++ b/src/test/java/com/example/grpcdemo/service/EnterpriseOnboardingServiceTest.java
@@ -154,6 +154,8 @@ class EnterpriseOnboardingServiceTest {
         OnboardingStepRecordDto record = state.getRecords().get(0);
         assertEquals(1, record.getStep());
         assertEquals("测试企业", record.getPayload().get("companyName"));
+        assertEquals("中国", record.getPayload().get("countryDisplayName"));
+        assertEquals("北京市", record.getPayload().get("cityDisplayName"));
 
         EnterpriseStep1Request updated = new EnterpriseStep1Request();
         updated.setUserId("user-1");


### PR DESCRIPTION
## Summary
- ensure onboarding state responses retain the localized record payloads
- extend the onboarding service unit test to verify localized country and city names are exposed

## Testing
- `./mvnw -q -Dtest=EnterpriseOnboardingServiceTest test` *(fails: unable to download Maven distribution in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ab591a1883318da2fa837484822f