### PR TITLE
docs: align auth and candidate docs with implementation

### DIFF
--- a/技术接口文档&数据库基本结构.md
+++ b/技术接口文档&数据库基本结构.md
@@ -1,34 +1,36 @@
 # 一,登陆注册页面接口技术文档
   ## 1.沿用原有官网的登陆注册流程
   ## 2.接口设计：
-    企业端（role:company）
-      POST /api/b/auth/send-code（发送注册验证码）
-      POST /api/b/auth/register（注册：验证码+密码）
-      POST /api/b/auth/login（登录：邮箱+密码）
-    工程师端（role:engineer）
-      POST /api/c/auth/send-code
-      POST /api/c/auth/register
-      POST /api/c/auth/login
+    所有账号体系接口由 `AuthController` 暴露，统一的前缀为 `/api/{segment}/auth/...`。`{segment}` 支持 `b`/`company`（企业端）和 `c`/`engineer`（工程师端），内部会映射到对应的 `AuthRole`。
+    | 方法 | URI | 描述 |
+    | --- | --- | --- |
+    | `POST` | `/api/{segment}/auth/password/reset/send-code` | 发送验证码。请求体包含 `email` 与 `purpose`（`REGISTER` 或 `RESET_PASSWORD`），用于注册和找回密码两个场景。|
+    | `POST` | `/api/{segment}/auth/register` | 注册：校验验证码并创建用户，返回访问与刷新令牌。|
+    | `POST` | `/api/{segment}/auth/login` | 登录：邮箱+密码校验，返回访问与刷新令牌。|
+    | `POST` | `/api/{segment}/auth/password/reset` | 重置密码：校验验证码后写入新密码。|
   ## 3.数据库设计
-    user表
+    `user_accounts` 表
   | 字段                          | 类型                                | 说明        |
-  | `id`                        | UUID                              | 主键        |
+  | `user_id`                   | UUID PRIMARY KEY                 | 主键        |
   | `email`                     | CITEXT UNIQUE                     | 登录邮箱（忽略大小写） |
-  | `password_hash`             | VARCHAR                           | BCrypt 哈希 |
-  | `role`                      | ENUM(company, engineer, admin)   | 角色（与接口中的 role 参数一致） |
-  | `status`                    | ENUM(ACTIVE, PENDING, LOCKED)     | 状态        |
-  | `created_at` / `updated_at` | TIMESTAMP                         | 创建/更新时间   |
-  | `last_login_at`             | TIMESTAMP                         | 最近登录      |
-    
-    验证码表 verification_tokens
-  | 字段           | 类型                                  | 说明     |
-  | `id`         | UUID                                | 主键     |
-  | `email`      | VARCHAR(255)                        | 对应用户邮箱 |
-  | `code`       | VARCHAR(6)                          | 验证码    |
-  | `purpose`    | ENUM(REGISTRATION, RESET\_PASSWORD) | 用途     |
-  | `expires_at` | TIMESTAMP                           | 过期时间   |
-  | `consumed`   | BOOLEAN                             | 是否已使用  |
-  | `created_at` | TIMESTAMP                           | 创建时间   |
+  | `password_hash`             | TEXT                              | BCrypt 哈希 |
+  | `role`                      | VARCHAR(32)                       | 角色（company/engineer/admin，对应 `AuthRole.alias()`）|
+  | `status`                    | VARCHAR(16)                       | 状态（`ACTIVE`/`PENDING`/`LOCKED`）|
+  | `created_at` / `updated_at` | TIMESTAMPTZ                       | 创建/更新时间（由触发器维护）|
+  | `last_login_at`             | TIMESTAMPTZ                       | 最近登录      |
+
+    验证码表 `auth_verification_codes`
+  | 字段             | 类型            | 说明 |
+  | `code_id`       | UUID PRIMARY KEY | 验证码记录 ID |
+  | `email`         | VARCHAR(255)     | 对应用户邮箱（已标准化）|
+  | `role`          | VARCHAR(32)      | 入口角色（company/engineer/admin）|
+  | `purpose`       | VARCHAR(32)      | `REGISTER` 或 `RESET_PASSWORD` |
+  | `code`          | VARCHAR(16)      | 验证码内容 |
+  | `expires_at`    | TIMESTAMPTZ      | 过期时间（默认 5 分钟）|
+  | `consumed`      | BOOLEAN          | 是否已使用 |
+  | `last_sent_at`  | TIMESTAMPTZ      | 上次发送时间（用于 1 分钟的重发间隔控制）|
+  | `request_id`    | UUID             | 对应的发送请求 ID，便于追踪日志 |
+  | `created_at` / `updated_at` | TIMESTAMPTZ | 创建/更新时间（`updated_at` 由触发器刷新）|
 
 # 二,企业端注册四步引导功能
   ## 1.功能概述
@@ -198,17 +200,23 @@
   # 五,企业端岗位候选人导入与管理
    ## 1.功能概述
      在企业端岗位详情页支持批量导入候选人简历，自动解析并维护候选人信息、状态、邮件邀约与面试记录。
-   ## 2.状态机定义（JobCandidateStatus）
-     | 状态代码             | 描述          | 触发条件                  |
-     | `INVITE_PENDING` | 待邀约         | HR 尚未发送邮件，邮箱有效        |
-     | `INVITE_SENT`    | 已发送邀约 / 未面试 | 通知服务发送成功，但候选人未开始面试    |
-     | `IN_PROGRESS`    | 面试中         | 候选人正在答题               |
-     | `COMPLETED`      | 已面试         | 面试提交完成，生成面试记录         |
-     | `REPORT_READY`   | 报告已生成       | Report Service 完成评估报告 |
-     | `DECLINED`       | 已放弃         | 候选人主动放弃（邮件链接）         |
-     | `TIMEOUT`        | 已超时         | 邀约超过 15 天未响应          |
-     | `EMAIL_MISSING`  | 邮箱缺失        | 解析未得到邮箱               |
-     | `INVALID`        | 解析失败        | AI 解析异常或文件损坏          |
+   ## 2.状态机定义
+     ### 邀约状态（`JobCandidateInviteStatus`）
+     | 状态代码 | 描述 | 维护服务 |
+     | --- | --- | --- |
+     | `INVITE_PENDING` | 已解析出邮箱，等待发送邀约。 | `CompanyJobCandidateService.importCandidates` 在导入成功且邮箱有效时设置；清空邮箱或手动改为缺失状态时也会恢复为该值。|
+     | `INVITE_SENT` | 已成功发送邀约邮件。 | `CompanyJobCandidateService.sendInvite` 调用邮件服务成功后写入。|
+     | `INVITE_FAILED` | 邮件发送失败，需重试。 | `CompanyJobCandidateService.sendInvite` 捕获 `MailException` 时写入。|
+     | `EMAIL_MISSING` | 缺少邮箱或邮箱无效，无法发送邀约。 | 导入解析未取到邮箱时由 `importCandidates` 设置；更新候选人信息时如果邮箱被清空，也会改为该状态。|
+
+     ### 面试状态（`JobCandidateInterviewStatus`）
+     | 状态代码 | 描述 | 维护服务 |
+     | --- | --- | --- |
+     | `NOT_INTERVIEWED` | 尚未安排面试。 | 导入候选人时由 `CompanyJobCandidateService.importCandidates` 设置默认值。|
+     | `SCHEDULED` | 已安排面试待执行。 | 目前通过企业后台的 `updateCandidate` 接口手动维护；后续与 `InterviewService` 打通后由面试排期流程更新。|
+     | `IN_PROGRESS` | 面试进行中。 | 预留给在线面试流程，通过 `updateCandidate` 或未来的实时同步更新。|
+     | `COMPLETED` | 面试已完成。 | 面试完成后由 `InterviewService` 或运营同学通过 `updateCandidate` 标记。|
+     | `CANCELLED` | 面试取消或候选人放弃。 | 由企业后台或面试服务在候选人取消时写入。|
   ## 3.API 设计
      1）候选人批量导入
        - 接口：`POST /api/enterprise/jobs/{positionId}/candidates/import`


### PR DESCRIPTION
## Summary
- document the actual `/api/{segment}/auth/...` routes exposed by `AuthController`
- update authentication schema details to reflect the `user_accounts` and `auth_verification_codes` tables
- replace the outdated JobCandidate status table with invite/interview status enums and note which services maintain each state

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e1ab5b0f308331acdc6807bbf1cbce