### PR TITLE
Fix protobuf plugin version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <plugin>
       <groupId>org.xolstice.maven.plugins</groupId>
       <artifactId>protobuf-maven-plugin</artifactId>
-      <version>0.7.3</version>
+      <version>0.6.1</version>
       <configuration>
         <protocArtifact>
           com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}


### PR DESCRIPTION
## Summary
- set the protobuf-maven-plugin version to 0.6.1 so Maven can resolve it from Central

## Testing
- ⚠️ `./mvnw -U generate-sources` *(fails: wget cannot download Maven distribution in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c49683948331b3564b039376de34