### PR TITLE
Add invited and timed out counts to candidate status summary

### DIFF
--- a/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateStatusSummary.java
+++ b/src/main/java/com/example/grpcdemo/controller/dto/JobCandidateStatusSummary.java
@@ -7,12 +7,16 @@ public class JobCandidateStatusSummary {
 
     /** 待邀约（包含邮箱缺失、邀约失败等情况）。 */
     private long waitingInvite;
+    /** 已成功发出邀约。 */
+    private long invited;
     /** 未进行面试（包含已安排但未完成）。 */
     private long notInterviewed;
     /** 已完成面试。 */
     private long interviewed;
     /** 已放弃或已取消。 */
     private long dropped;
+    /** 已超时未响应邀约。 */
+    private long timedOut;
     /** 全部候选人数量。 */
     private long all;
 
@@ -22,6 +26,14 @@ public class JobCandidateStatusSummary {
 
     public void setWaitingInvite(long waitingInvite) {
         this.waitingInvite = waitingInvite;
+    }
+
+    public long getInvited() {
+        return invited;
+    }
+
+    public void setInvited(long invited) {
+        this.invited = invited;
     }
 
     public long getNotInterviewed() {
@@ -46,6 +58,14 @@ public class JobCandidateStatusSummary {
 
     public void setDropped(long dropped) {
         this.dropped = dropped;
+    }
+
+    public long getTimedOut() {
+        return timedOut;
+    }
+
+    public void setTimedOut(long timedOut) {
+        this.timedOut = timedOut;
     }
 
     public long getAll() {

--- a/src/main/java/com/example/grpcdemo/service/CompanyJobCandidateService.java
+++ b/src/main/java/com/example/grpcdemo/service/CompanyJobCandidateService.java
@@ -707,6 +707,9 @@ public class CompanyJobCandidateService {
                 + candidateRepository.countByPositionIdAndInviteStatus(positionId, JobCandidateInviteStatus.INVITE_FAILED);
         summary.setWaitingInvite(waitingInvite);
 
+        long invited = candidateRepository.countByPositionIdAndInviteStatus(positionId, JobCandidateInviteStatus.INVITE_SENT);
+        summary.setInvited(invited);
+
         long notInterviewed = candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.NOT_INTERVIEWED)
                 + candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.SCHEDULED)
                 + candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.IN_PROGRESS);
@@ -719,6 +722,9 @@ public class CompanyJobCandidateService {
                 + candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.ABANDONED)
                 + candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.TIMED_OUT);
         summary.setDropped(dropped);
+
+        long timedOut = candidateRepository.countByPositionIdAndInterviewStatus(positionId, JobCandidateInterviewStatus.TIMED_OUT);
+        summary.setTimedOut(timedOut);
 
         summary.setAll(candidateRepository.countByPositionId(positionId));
         return summary;


### PR DESCRIPTION
## Summary
- add invited and timed-out aggregates to the candidate status summary payload
- populate the new summary fields from repository counts when building the response

## Testing
- ./mvnw -q test *(fails: wget unable to fetch apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f4cbd7dc83318d6ce062e657eb7a