### PR TITLE
Fix protobuf plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <protocArtifact>
           com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
         </protocArtifact>
-        <cleanOutputDirectory>true</cleanOutputDirectory>
+        <clearOutputDirectory>true</clearOutputDirectory>
       </configuration>
       <executions>
         <execution>
@@ -197,7 +197,7 @@
           <configuration>
             <pluginId>grpc-java</pluginId>
             <pluginArtifact>
-              io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+              io.grpc:protoc-gen-grpc-java:${grpc.version}
             </pluginArtifact>
           </configuration>
         </execution>


### PR DESCRIPTION
## Summary
- correct the protobuf Maven plugin configuration so the generated sources directory is cleared reliably
- switch the gRPC protoc plugin artifact to the portable Java distribution to avoid missing proto path errors during generation

## Testing
- not run (Maven wrapper download blocked in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4a82dbf708331963edbe83dae522b