### PR TITLE
Fix properties plugin goal for proto skip toggle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
           <id>flag-proto-generated</id>
           <phase>generate-sources</phase>
           <goals>
-            <goal>set-property</goal>
+            <goal>set-system-properties</goal>
           </goals>
           <configuration>
             <properties>


### PR DESCRIPTION
## Summary
- replace the unavailable properties-maven-plugin `set-property` goal with `set-system-properties`
- continue flipping the `proto.skip` flag after the first protobuf generation run without causing a build failure

## Testing
- `./mvnw -q -U clean generate-sources -DskipTests compile` *(fails in this environment because Maven Wrapper cannot download Maven binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68e4af4810d88331a9eef681cdf12d32