### PR TITLE
Fix gRPC client factory channel injection

### DIFF
--- a/src/main/java/com/example/grpcdemo/gateway/GatewayGrpcClientFactory.java
+++ b/src/main/java/com/example/grpcdemo/gateway/GatewayGrpcClientFactory.java
@@ -16,14 +16,20 @@ import net.devh.boot.grpc.client.inject.GrpcClient;
 @Component
 public class GatewayGrpcClientFactory {
 
-    private final ManagedChannel channel;
+    private final Channel channel;
+    private final ManagedChannel managedChannel;
 
-    public GatewayGrpcClientFactory(@GrpcClient("usersvc") ManagedChannel channel) {
+    public GatewayGrpcClientFactory(@GrpcClient("usersvc") Channel channel) {
         this.channel = channel;
+        if (channel instanceof ManagedChannel managedChannel) {
+            this.managedChannel = managedChannel;
+        } else {
+            throw new IllegalStateException("Injected gRPC channel does not support ManagedChannel operations");
+        }
     }
 
     public ManagedChannel managedChannel() {
-        return channel;
+        return managedChannel;
     }
 
     public Channel channel() {


### PR DESCRIPTION
## Summary
- inject the REST gateway gRPC channel using the supported io.grpc.Channel type
- retain ManagedChannel functionality by casting the injected channel when possible

## Testing
- ./mvnw -q -DskipTests package *(fails: unable to download Maven binaries due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68f2669267b48331a053902b745077c1