### PR TITLE
Configure Supabase JWKS for resource server

### DIFF
--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -12,7 +12,7 @@
 ```bash
 # Supabase 相关
 SUPABASE_PROJECT_URL=https://<project>.supabase.co
-SUPABASE_JWKS_URL=https://<project>.supabase.co/auth/v1/jwks
+SUPABASE_JWKS_URL=https://<project>.supabase.co/auth/v1/.well-known/jwks.json
 SUPABASE_SERVICE_ROLE_KEY=...           # 后端使用，请勿下发前端
 
 # 数据库连接

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,11 @@ app:
     stub-enabled: true
   rabbit:
     enabled: false
+  auth:
+    mode: supabase
+    supabase:
+      project-url: https://ecqxglofqhtfkmjcgefi.supabase.co
+      jwks-url: https://ecqxglofqhtfkmjcgefi.supabase.co/auth/v1/.well-known/jwks.json
 
 spring:
   datasource:
@@ -43,7 +48,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: https://ecqxglofqhtfkmjcgefi.supabase.co/auth/v1/keys
+          jwk-set-uri: https://ecqxglofqhtfkmjcgefi.supabase.co/auth/v1/.well-known/jwks.json
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary
- configure the default Supabase project and JWKS endpoints in application.yml
- point the Spring resource server JWT decoder at Supabase's well-known JWKS document
- update the frontend integration guide to reference the well-known JWKS URL

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68f301dc65ec8331a15037ac6c193a13